### PR TITLE
feat: request connection

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -21,7 +21,7 @@
     "webpack-cli": "^4.9.1"
   },
   "scripts": {
-    "build": "webpack",
+    "build": "NODE_ENV=production webpack",
     "start": "webpack",
     "dev": "webpack --watch"
   },

--- a/packages/extension/src/app/App.tsx
+++ b/packages/extension/src/app/App.tsx
@@ -8,11 +8,13 @@ import { Account } from "./screens/Account"
 import { AccountListScreen } from "./screens/AccountList"
 import { AddToken } from "./screens/AddToken"
 import { ApproveTx } from "./screens/ApproveTx"
+import { ConnectScreen } from "./screens/Connect"
 import { DisclaimerScreen } from "./screens/Disclaimer"
 import { Loading } from "./screens/Loading"
 import { NewSeed } from "./screens/NewSeed"
 import { Password } from "./screens/Password"
 import { ResetScreen } from "./screens/Reset"
+import { Settings } from "./screens/Settings"
 import { Success } from "./screens/Success"
 import { UploadKeystore } from "./screens/UploadKeystore"
 import { Welcome } from "./screens/Welcome"
@@ -99,8 +101,24 @@ function App() {
   if (state.matches("submittedTx"))
     return <Success txHash={state.context.txHash} />
 
+  if (state.matches("connect"))
+    return (
+      <ConnectScreen
+        host={state.context.hostToWhitelist}
+        onReject={() => {
+          send("REJECT")
+        }}
+        onSubmit={() => {
+          send("AGREE")
+        }}
+      />
+    )
+
   if (state.matches("disclaimer"))
     return <DisclaimerScreen onSubmit={() => send("AGREE")} />
+
+  if (state.matches("settings"))
+    return <Settings onBack={() => send("GO_BACK")} />
 
   if (state.matches("account"))
     return (
@@ -149,6 +167,7 @@ function App() {
         wallets={Object.values(state.context.wallets)}
         activeWallet={state.context.selectedWallet}
         onAddAccount={() => send("ADD_WALLET")}
+        onSettings={() => send("SHOW_SETTINGS")}
         onAccountSelect={(address) => {
           send({ type: "SELECT_WALLET", data: address })
         }}

--- a/packages/extension/src/app/screens/AccountList.tsx
+++ b/packages/extension/src/app/screens/AccountList.tsx
@@ -1,8 +1,8 @@
 import { FC } from "react"
 import styled from "styled-components"
 
-// import Settings from '../../assets/settings.svg';
 import Add from "../../assets/add.svg"
+import Settings from "../../assets/settings.svg"
 import { AccountRow } from "../components/Account/Header"
 import { AccountList, AccountListItem } from "../components/Account/List"
 import { IconButton } from "../components/IconButton"
@@ -25,10 +25,10 @@ const AccountListWrapper = styled.div`
     margin-top: 32px;
     width: 100%;
   }
+`
 
-  ${IconButton} {
-    margin: auto;
-  }
+const IconButtonCenter = styled(IconButton)`
+  margin: auto;
 `
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -37,6 +37,7 @@ const noop = () => {}
 interface AccountListPageProps {
   onAccountSelect?: (account: string) => void
   onAddAccount?: () => void
+  onSettings?: () => void
   wallets: Wallet[]
   activeWallet: string
 }
@@ -44,6 +45,7 @@ interface AccountListPageProps {
 export const AccountListScreen: FC<AccountListPageProps> = ({
   onAccountSelect = noop,
   onAddAccount = noop,
+  onSettings = noop,
   wallets,
   activeWallet,
 }) => {
@@ -51,9 +53,9 @@ export const AccountListScreen: FC<AccountListPageProps> = ({
     <AccountListWrapper>
       <AccountRow>
         <H2>Accounts</H2>
-        {/* <IconButton size={32}>
+        <IconButton size={32} {...makeClickable(onSettings, 99)}>
           <Settings />
-        </IconButton> */}
+        </IconButton>
       </AccountRow>
       <AccountList>
         {wallets.map((wallet, index) => {
@@ -69,9 +71,9 @@ export const AccountListScreen: FC<AccountListPageProps> = ({
             />
           )
         })}
-        <IconButton size={48} {...makeClickable(onAddAccount)}>
+        <IconButtonCenter size={48} {...makeClickable(onAddAccount)}>
           <Add />
-        </IconButton>
+        </IconButtonCenter>
       </AccountList>
     </AccountListWrapper>
   )

--- a/packages/extension/src/app/screens/Connect.tsx
+++ b/packages/extension/src/app/screens/Connect.tsx
@@ -1,0 +1,27 @@
+import { FC } from "react"
+import styled from "styled-components"
+
+import { P } from "../components/Typography"
+import { Confirm, ConfirmPageProps } from "./Confirm"
+
+interface ConnectProps extends ConfirmPageProps {
+  host: string
+}
+
+const Code = styled.code`
+  background-color: rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
+  padding: 0 0.5em;
+`
+
+export const ConnectScreen: FC<ConnectProps> = ({ host, ...props }) => {
+  return (
+    <Confirm title="Connect to DApp" confirmButtonText="Connect" {...props}>
+      <P>
+        <Code>{host}</Code> tries to connect to your wallet. If you allow this
+        request the website will be able to read you wallet addresses and
+        request transactions, which you still need to sign.
+      </P>
+    </Confirm>
+  )
+}

--- a/packages/extension/src/app/screens/Settings.tsx
+++ b/packages/extension/src/app/screens/Settings.tsx
@@ -1,0 +1,39 @@
+import { FC } from "react"
+import styled from "styled-components"
+
+import { BackButton } from "../components/BackButton"
+import { Button } from "../components/Button"
+import { H2, P } from "../components/Typography"
+import { messenger } from "../utils/messaging"
+
+const SettingsScreen = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 48px 32px;
+
+  > ${P} {
+    margin: 16px 0;
+  }
+`
+
+export const Settings: FC<{ onBack?: () => void }> = ({ onBack }) => {
+  return (
+    <SettingsScreen>
+      <BackButton onClick={onBack} />
+      <H2>Settings</H2>
+      <P>
+        You can reset the whitelist of DApps, so all DApps which want to connect
+        to your wallet in the future need to go through the whitelist process
+        again:
+      </P>
+      <Button
+        onClick={() => {
+          messenger.emit("RESET_WHITELIST", {})
+          onBack?.()
+        }}
+      >
+        Reset whitelist
+      </Button>
+    </SettingsScreen>
+  )
+}

--- a/packages/extension/src/app/states/RouterMachine.ts
+++ b/packages/extension/src/app/states/RouterMachine.ts
@@ -43,7 +43,7 @@ type RouterEvents =
   | { type: "APPROVED_TX" }
   | { type: "GENERATE_L1"; data: { password: string } }
 
-type Context = {
+interface Context {
   password?: string
   selectedWallet?: string
   l1?: ethers.Wallet

--- a/packages/extension/src/app/utils/messaging.ts
+++ b/packages/extension/src/app/utils/messaging.ts
@@ -8,7 +8,6 @@ const port = browser.runtime.connect({ name: "argent-x-ui" })
 export const messenger = new Messenger(
   (emit) => {
     port.onMessage.addListener(function (msg) {
-      console.log(msg)
       if (msg.from && msg.type && allowedSender.includes(msg.from)) {
         const { type, data } = msg
         emit(type, data)

--- a/packages/extension/src/app/utils/messaging.ts
+++ b/packages/extension/src/app/utils/messaging.ts
@@ -8,6 +8,7 @@ const port = browser.runtime.connect({ name: "argent-x-ui" })
 export const messenger = new Messenger(
   (emit) => {
     port.onMessage.addListener(function (msg) {
+      console.log(msg)
       if (msg.from && msg.type && allowedSender.includes(msg.from)) {
         const { type, data } = msg
         emit(type, data)
@@ -15,13 +16,18 @@ export const messenger = new Messenger(
     })
   },
   (type, data) => {
-    port.postMessage({ from: "INJECT", type, data })
+    port.postMessage({ from: "UI", type, data })
   },
 )
 
 export const readRequestedTransactions = async (): Promise<Transaction[]> => {
   messenger.emit("READ_REQUESTED_TRANSACTIONS", {})
   return messenger.waitForEvent("READ_REQUESTED_TRANSACTIONS_RES", 2000)
+}
+
+export const readPendingWhitelist = async (): Promise<string[]> => {
+  messenger.emit("GET_PENDING_WHITELIST", {})
+  return messenger.waitForEvent("GET_PENDING_WHITELIST_RES", 2000)
 }
 
 export const getLastSelectedWallet = async (): Promise<string | undefined> => {

--- a/packages/extension/src/inpage.ts
+++ b/packages/extension/src/inpage.ts
@@ -56,9 +56,11 @@ const starknetWindowObject: StarknetWindowObject = {
   isConnected: false,
   enable: () =>
     new Promise((res) => {
-      messenger.emit("CONNECT", {})
+      messenger.emit("CONNECT", {
+        host: window.location.hostname,
+      })
       messenger.listen((type, data) => {
-        if (type === "WALLET_CONNECTED" && typeof data === "string") {
+        if (type === "CONNECT_RES" && typeof data === "string") {
           ;(window as any).starknet.signer = new WalletSigner(data)
           ;(window as any).starknet.selectedAddress = data
           ;(window as any).starknet.isConnected = true

--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -7,6 +7,9 @@ const htmlPlugin = new HtmlWebPackPlugin({
   filename: "./index.html",
 })
 
+const isProd = process.env.NODE_ENV === "production"
+console.log("NODE_ENV", process.env.NODE_ENV)
+
 module.exports = {
   entry: {
     main: "./src/index",
@@ -15,7 +18,7 @@ module.exports = {
     background: "./src/background",
   },
   devtool: "inline-source-map",
-  mode: "development",
+  mode: isProd ? "production" : "development",
   module: {
     rules: [
       {

--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -8,7 +8,6 @@ const htmlPlugin = new HtmlWebPackPlugin({
 })
 
 const isProd = process.env.NODE_ENV === "production"
-console.log("NODE_ENV", process.env.NODE_ENV)
 
 module.exports = {
   entry: {


### PR DESCRIPTION
https://argent.atlassian.net/browse/BLO-12

We need to be carefull not to expose the provider in window to every app. We should check how MetaMask does that as they had to change that specific behaviour.

Upon connecting the wallet from a dapp, the extension should open and request to connect to that specific dapp. The provider with the account, etc should only be injected if approved. The extension should keep a mapping of the approved dapps.




This MR also improves encryption/decryption when development mode is detected