### PR TITLE
Add a list of default tokens

### DIFF
--- a/packages/extension/src/app/screens/Account.tsx
+++ b/packages/extension/src/app/screens/Account.tsx
@@ -86,9 +86,9 @@ const TokenList: FC<{
         <TokenListItem
           key={i}
           index={i}
-          decimals={token.decimals!.toNumber()}
+          decimals={token.decimals?.toNumber()}
           balance={
-            ethers.utils.formatUnits(token.balance!, token.decimals!) || "0"
+            ethers.utils.formatUnits(token.balance ?? 0, token.decimals) || "0"
           }
           name={token.name || ""}
           symbol={token.symbol || ""}

--- a/packages/extension/src/app/utils/tokens.ts
+++ b/packages/extension/src/app/utils/tokens.ts
@@ -3,6 +3,11 @@ import mitt from "mitt"
 import { Abi, Contract } from "starknet"
 
 import parsedErc20Abi from "../../abi/ERC20.json"
+import erc20Tokens from "../../assets/erc20-tokens.json"
+
+const defaultErc20s = Object.fromEntries(
+  erc20Tokens.map((token) => [token.address, token]),
+)
 
 export const tokensMitt =
   mitt<{ UPDATE: { wallet: string; tokens: string[] } }>()
@@ -11,19 +16,21 @@ tokensMitt.on("UPDATE", ({ wallet, tokens }) => {
   localStorage.setItem(`tokens:${wallet}`, JSON.stringify(tokens))
 })
 
-export const getTokens = (wallet: string): string[] => {
+const getStoredTokens = (wallet: string): string[] => {
   try {
     const storedTokens = localStorage.getItem(`tokens:${wallet}`)
 
     if (storedTokens) {
       return JSON.parse(storedTokens)
     }
-
-    return []
-  } catch {
-    return []
-  }
+  } catch {}
+  return []
 }
+
+export const getTokens = (wallet: string): string[] =>
+  Array.from(
+    new Set([...Object.keys(defaultErc20s), ...getStoredTokens(wallet)]),
+  )
 
 export const isValidAddress = (address: string): boolean =>
   /^0x[0-9a-f]{63}$/.test(address)
@@ -35,7 +42,7 @@ export const addToken = (
   if (!isValidAddress(token.address)) throw Error("token address malformed")
 
   localStorage.setItem(
-    `wallet:${wallet}token:${token.address}`,
+    `wallet:${wallet}:token:${token.address}`,
     JSON.stringify(token),
   )
 
@@ -59,33 +66,33 @@ export const fetchTokenDetails = async (
   const [decimals, name, balance, symbol] = await Promise.all([
     tokenContract
       .call("decimals")
-      .then((x) => x.res)
+      .then((x) => x.res as string)
       .catch(() => ""),
     tokenContract
       .call("name")
-      .then((x) => x.res)
+      .then((x) => x.res as string)
       .catch(() => ""),
     tokenContract
       .call("balance_of", { user: walletAddress })
-      .then((x) => x.res)
+      .then((x) => x.res as string)
       .catch(() => ""),
     tokenContract
       .call("symbol")
-      .then((x) => x.res)
+      .then((x) => x.res as string)
       .catch(() => ""),
   ])
   const localStorageBackup: TokenDetails = JSON.parse(
-    localStorage.getItem(`wallet:${walletAddress}token:${address}`) || "{}",
+    localStorage.getItem(`wallet:${walletAddress}:token:${address}`) || "{}",
+  )
+  const defaultBackup = defaultErc20s[address] || {}
+  const decimalsBigNumber = BigNumber.from(
+    decimals || localStorageBackup.decimals || defaultBackup.decimals || 0,
   )
   return {
     address,
-    name: name ? (name as string) : localStorageBackup.name ?? undefined,
-    symbol: symbol
-      ? (symbol as string)
-      : localStorageBackup.symbol ?? undefined,
+    name: name || localStorageBackup.name || defaultBackup.name,
+    symbol: symbol || localStorageBackup.symbol || defaultBackup.symbol,
     balance: balance ? BigNumber.from(balance) : undefined,
-    decimals: decimals
-      ? BigNumber.from(decimals)
-      : BigNumber.from(localStorageBackup.decimals) ?? undefined,
+    decimals: decimalsBigNumber.isZero() ? decimalsBigNumber : undefined,
   }
 }

--- a/packages/extension/src/assets/erc20-tokens.json
+++ b/packages/extension/src/assets/erc20-tokens.json
@@ -1,0 +1,8 @@
+[
+  {
+    "address": "0x4e3920043b272975b32dfc0121817d6e6a943dc266d7ead1e6152e472201f97",
+    "name": "Playground Token",
+    "symbol": "TEST",
+    "decimals": "18"
+  }
+]


### PR DESCRIPTION
Add a list of basic, "well known" ERC20 tokens in the extension's code to avoid showing an empty wallet when a user recovers an existing wallet.

Might need to check how often token details are cached and refreshed as this list grows in size.