### PR TITLE
feat: persist swr cache

### DIFF
--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react"
 import { uint256 } from "starknet"
 import { createGlobalStyle } from "styled-components"
 import { normalize } from "styled-normalize"
+import { SWRConfig } from "swr"
 
 import { AccountListScreen } from "./screens/AccountListScreen"
 import { AccountScreen } from "./screens/AccountScreen"
@@ -21,6 +22,7 @@ import { TokenScreen } from "./screens/TokenScreen"
 import { UploadKeystoreScreen } from "./screens/UploadKeystoreScreen"
 import { WelcomeScreen } from "./screens/WelcomeScreen"
 import { routerMachine } from "./states/RouterMachine"
+import { swrCacheProvider } from "./utils/swrCache"
 import { TokenDetails } from "./utils/tokens"
 
 function getUint256CalldataFromBN(bn: BigNumber) {
@@ -277,14 +279,16 @@ const GlobalStyle = createGlobalStyle`
 `
 
 export default () => (
-  <Suspense fallback={<LoadingScreen />}>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700;900&display=swap"
-      rel="stylesheet"
-    />
-    <GlobalStyle />
-    <App />
-  </Suspense>
+  <SWRConfig value={{ provider: () => swrCacheProvider }}>
+    <Suspense fallback={<LoadingScreen />}>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700;900&display=swap"
+        rel="stylesheet"
+      />
+      <GlobalStyle />
+      <App />
+    </Suspense>
+  </SWRConfig>
 )

--- a/packages/extension/src/ui/components/Account/TokenList.tsx
+++ b/packages/extension/src/ui/components/Account/TokenList.tsx
@@ -41,7 +41,7 @@ export const TokenList: FC<TokenListProps> = ({
         ),
       ),
 
-    { suspense: true, refreshInterval: 5000 },
+    { suspense: true, refreshInterval: 30000 },
   )
 
   const hasBalance = tokenDetails.some(

--- a/packages/extension/src/ui/utils/swrCache.ts
+++ b/packages/extension/src/ui/utils/swrCache.ts
@@ -1,0 +1,32 @@
+import { BigNumber } from "ethers"
+import { Cache } from "swr"
+
+export const swrCacheProvider: Cache = {
+  set: (key: string, value: any) => {
+    localStorage.setItem(key, JSON.stringify(value))
+  },
+  get: (key: string) => {
+    const value = localStorage.getItem(key)
+    try {
+      if (!value) throw Error("no value")
+      return (
+        JSON.parse(value, (k, v) => {
+          if (
+            typeof v === "object" &&
+            "type" in v &&
+            "hex" in v &&
+            v.type === "BigNumber"
+          ) {
+            return BigNumber.from(v.hex)
+          }
+          return v
+        }) ?? undefined
+      )
+    } catch {
+      return undefined
+    }
+  },
+  delete: (key: string) => {
+    localStorage.removeItem(key)
+  },
+}


### PR DESCRIPTION
this allows SWR to write the cache to localstorage and retrieve when asked. This will persist token balances between extension restarts and fetch the new balance in the background