### PR TITLE
feat(local-network): initial implementation

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -22,7 +22,7 @@ import {
   startSession,
   stopSession,
 } from "./session"
-import { Storage, setToStorage } from "./storage"
+import { setToStorage } from "./storage"
 import { addToWhitelist, isOnWhitelist, removeFromWhitelist } from "./whitelist"
 
 let activeTabId: number | undefined

--- a/packages/extension/src/background/keys/l1.ts
+++ b/packages/extension/src/background/keys/l1.ts
@@ -4,6 +4,7 @@ import { Provider, compileCalldata, ec, stark } from "starknet"
 import browser from "webextension-polyfill"
 
 import { BackupWallet } from "../../shared/backup.model"
+import { Network, getProvider } from "../../shared/networks"
 import { selectedWalletStore } from "../selectedWallet"
 import { Storage } from "../storage"
 
@@ -143,7 +144,7 @@ export async function createAccount(password: string, networkId: string) {
   const seed = ec.getStarkKey(ec.genKeyPair())
   const wallets = await getWallets()
 
-  const provider = new Provider({ network: networkId as any })
+  const provider = getProvider(networkId)
   const deployTransaction = await provider.deployContract(
     ArgentCompiledContract,
     compileCalldata({

--- a/packages/extension/src/inpage/index.ts
+++ b/packages/extension/src/inpage/index.ts
@@ -9,6 +9,7 @@ import {
 } from "starknet"
 
 import { MessageType, WindowMessageType } from "../shared/MessageType"
+import { getProvider } from "../shared/networks"
 import { EventHandler, StarknetWindowObject } from "./model"
 
 const extId = document
@@ -41,7 +42,7 @@ const starknetWindowObject: StarknetWindowObject = {
         if (data.type === "CONNECT_RES" && data.data) {
           window.removeEventListener("message", handleMessage)
           const { address, network } = data.data
-          starknet.provider = new Provider({ network: network as any })
+          starknet.provider = getProvider(network)
           starknet.signer = new WalletSigner(address, starknet.provider)
           starknet.selectedAddress = address
           starknet.isConnected = true
@@ -77,7 +78,7 @@ window.addEventListener(
       const { address, network } = data.data
       if (address !== starknet.selectedAddress) {
         starknet.selectedAddress = address
-        starknet.provider = new Provider({ network: network as any })
+        starknet.provider = getProvider(network)
         starknet.signer = new WalletSigner(address, starknet.provider)
         for (const handleEvent of userEventHandlers) {
           handleEvent([address])

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -12,7 +12,7 @@
     "default_title": "Argent X",
     "default_popup": "index.html"
   },
-  "permissions": ["downloads", "tabs", "storage"],
+  "permissions": ["downloads", "tabs", "storage", "http://localhost/*"],
   "icons": {
     "16": "assets/logo.png",
     "48": "assets/logo.png",

--- a/packages/extension/src/shared/networks.ts
+++ b/packages/extension/src/shared/networks.ts
@@ -1,12 +1,15 @@
+import { Provider } from "starknet"
+
+import { BackupWallet } from "./backup.model"
+
 export interface Network {
   id: string
   name: string
-  explorerUrl: string
+  baseUrl?: string
+  explorerUrl?: string
 }
 
-export const defaultNetworkId = "goerli-alpha"
-
-export const defaultNetworks: Network[] = [
+export const networks: Network[] = [
   {
     id: "mainnet-alpha",
     name: "Ethereum Mainnet",
@@ -17,7 +20,33 @@ export const defaultNetworks: Network[] = [
     name: "Goerli Testnet",
     explorerUrl: "https://goerli.voyager.online",
   },
+  {
+    id: "localhost",
+    name: "Localhost",
+  },
 ]
 
-export const getNetwork = (networkId: string) =>
-  defaultNetworks.find(({ id }) => id === networkId) || defaultNetworks[0]
+export const defaultNetwork = networks[1] // goerli-alpha
+
+export const getNetwork = (networkId: string): Network => {
+  networkId = localNetworkId(networkId)
+  return networks.find(({ id }) => id === networkId) || defaultNetwork
+}
+
+export const networkWallets = (wallets: BackupWallet[], networkId: string) =>
+  wallets.filter(
+    ({ network }) => localNetworkId(network) === localNetworkId(networkId),
+  )
+
+export const localNetworkId = (network: string) =>
+  network.startsWith("http://localhost") ? "localhost" : network
+
+export const localNetworkUrl = (networkId: string, port: number) =>
+  networkId === "localhost" ? `http://localhost:${port}` : networkId
+
+export const getProvider = (network: string) =>
+  new Provider(
+    network.startsWith("http")
+      ? { baseUrl: network }
+      : { network: network as any },
+  )

--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -153,6 +153,8 @@ function App() {
       <SettingsScreen
         onBack={() => send("GO_BACK")}
         onLock={() => send("LOCK")}
+        port={state.context.localhostPort}
+        onPortChange={(port) => send({ type: "CHANGE_PORT", data: port })}
       />
     )
 
@@ -201,6 +203,7 @@ function App() {
         onChangeNetwork={(networkId) => {
           send({ type: "CHANGE_NETWORK", data: networkId })
         }}
+        port={state.context.localhostPort}
       />
     )
   }
@@ -219,6 +222,7 @@ function App() {
         onChangeNetwork={(networkId) => {
           send({ type: "CHANGE_NETWORK", data: networkId })
         }}
+        port={state.context.localhostPort}
       />
     )
   }

--- a/packages/extension/src/ui/Wallet.ts
+++ b/packages/extension/src/ui/Wallet.ts
@@ -6,7 +6,6 @@ import {
   Calldata,
   CompiledContract,
   Contract,
-  Provider,
   compileCalldata,
   encode,
   hash,
@@ -16,6 +15,7 @@ import {
 } from "starknet"
 
 import { sendMessage, waitForMessage } from "../shared/messages"
+import { getProvider } from "../shared/networks"
 
 const ArgentCompiledContractJson: CompiledContract = json.parse(
   ArgentCompiledContract,
@@ -32,7 +32,7 @@ export class Wallet {
     this.contract = new Contract(
       ArgentCompiledContractJson.abi,
       address,
-      new Provider({ network: networkId as any }),
+      getProvider(networkId),
     )
 
     if (deployTransaction) {

--- a/packages/extension/src/ui/components/Account/EmptyWalletAlert.tsx
+++ b/packages/extension/src/ui/components/Account/EmptyWalletAlert.tsx
@@ -47,7 +47,7 @@ export const EmptyWalletAlert: FC<EmptyWalletAlertProps> = ({
   onAction,
 }) => (
   <AlertWrapper>
-    <Title>Deposit Funds</Title>
+    <Title>Deposit funds</Title>
     <Paragraph>
       Or learn how to deploy a contract and mint some tokens
     </Paragraph>

--- a/packages/extension/src/ui/components/NetworkSwitcher.tsx
+++ b/packages/extension/src/ui/components/NetworkSwitcher.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react"
 import styled from "styled-components"
 
-import { defaultNetworks, getNetwork } from "../../shared/networks"
+import { getNetwork, networks } from "../../shared/networks"
 import { WalletStatusCode } from "../utils/wallet"
 
 const NetworkName = styled.span`
@@ -99,25 +99,30 @@ export const NetworkStatusIndicator = styled.span<{
 interface NetworkSwitcherProps {
   networkId: string
   onChangeNetwork: (networkId: string) => Promise<void> | void
+  port: number
 }
 
 export const NetworkSwitcher: FC<NetworkSwitcherProps> = ({
   networkId,
   onChangeNetwork,
+  port,
 }) => {
   const currentNetwork = getNetwork(networkId)
-  const otherNetworks = defaultNetworks.filter(({ id }) => id !== networkId)
+  const otherNetworks = networks.filter((network) => network !== currentNetwork)
+
+  const formatName = (name: string) =>
+    name === "Localhost" ? `Localhost ${port}` : name
 
   return (
     <NetworkSwitcherWrapper>
       <Network selected>
-        <NetworkName>{currentNetwork.name}</NetworkName>
+        <NetworkName>{formatName(currentNetwork.name)}</NetworkName>
         <NetworkStatusIndicator status="CONNECTED" />
       </Network>
       <NetworkList>
         {otherNetworks.map(({ id, name }) => (
           <Network key={id} onClick={() => onChangeNetwork(id)}>
-            <NetworkName>{name}</NetworkName>
+            <NetworkName>{formatName(name)}</NetworkName>
             <NetworkStatusIndicator status="CONNECTED" />
           </Network>
         ))}

--- a/packages/extension/src/ui/screens/AccountListScreen.tsx
+++ b/packages/extension/src/ui/screens/AccountListScreen.tsx
@@ -41,6 +41,7 @@ interface AccountListScreenProps {
   activeWallet: string
   networkId: string
   onChangeNetwork: (networkId: string) => Promise<void> | void
+  port: number
 }
 
 export const AccountListScreen: FC<AccountListScreenProps> = ({
@@ -51,6 +52,7 @@ export const AccountListScreen: FC<AccountListScreenProps> = ({
   activeWallet,
   networkId,
   onChangeNetwork,
+  port,
 }) => (
   <AccountListWrapper>
     <Header>
@@ -60,6 +62,7 @@ export const AccountListScreen: FC<AccountListScreenProps> = ({
       <NetworkSwitcher
         networkId={networkId}
         onChangeNetwork={onChangeNetwork}
+        port={port}
       />
     </Header>
     <H1>Accounts</H1>

--- a/packages/extension/src/ui/screens/AccountScreen.tsx
+++ b/packages/extension/src/ui/screens/AccountScreen.tsx
@@ -37,6 +37,7 @@ interface AccountScreenProps {
   onAction?: (token: string, action: TokenAction) => Promise<void> | void
   networkId: string
   onChangeNetwork: (networkId: string) => Promise<void> | void
+  port: number
 }
 
 export const AccountScreen: FC<AccountScreenProps> = ({
@@ -48,6 +49,7 @@ export const AccountScreen: FC<AccountScreenProps> = ({
   onAction,
   networkId,
   onChangeNetwork,
+  port,
 }) => {
   const status = useStatus(wallet)
   return (
@@ -60,6 +62,7 @@ export const AccountScreen: FC<AccountScreenProps> = ({
         <NetworkSwitcher
           networkId={networkId}
           onChangeNetwork={onChangeNetwork}
+          port={port}
         />
       </Header>
       <AccountContent>

--- a/packages/extension/src/ui/screens/SettingsScreen.tsx
+++ b/packages/extension/src/ui/screens/SettingsScreen.tsx
@@ -5,6 +5,7 @@ import { sendMessage } from "../../shared/messages"
 import { BackButton } from "../components/BackButton"
 import { Button } from "../components/Button"
 import { Header } from "../components/Header"
+import { InputText } from "../components/Input"
 import { H2, P } from "../components/Typography"
 
 const SettingsScreenWrapper = styled.div`
@@ -24,9 +25,16 @@ const SettingsScreenWrapper = styled.div`
 interface SettingsScreenProps {
   onBack: () => void
   onLock: () => void
+  port: number
+  onPortChange: (port: number) => void
 }
 
-export const SettingsScreen: FC<SettingsScreenProps> = ({ onBack, onLock }) => (
+export const SettingsScreen: FC<SettingsScreenProps> = ({
+  onBack,
+  onLock,
+  port,
+  onPortChange,
+}) => (
   <>
     <Header>
       <BackButton onClick={onBack} />
@@ -53,6 +61,13 @@ export const SettingsScreen: FC<SettingsScreenProps> = ({ onBack, onLock }) => (
       >
         Lock wallet
       </Button>
+      <InputText
+        placeholder="Local node port number"
+        type="number"
+        value={port}
+        onChange={(e: any) => onPortChange(e.target.value)}
+        style={{ marginTop: 20 }}
+      />
     </SettingsScreenWrapper>
   </>
 )

--- a/packages/extension/src/ui/screens/SuccessScreen.tsx
+++ b/packages/extension/src/ui/screens/SuccessScreen.tsx
@@ -33,7 +33,10 @@ export const SuccessScreen: FC<SuccessScreenProps> = ({
   return (
     <SuccessScreenWrapper>
       <Spinner size={92} />
-      <SuccessText href={`${explorerUrl}/tx/${txHash}`} target="_blank">
+      <SuccessText
+        href={explorerUrl && `${explorerUrl}/tx/${txHash}`}
+        target="_blank"
+      >
         Transaction was submitted
       </SuccessText>
     </SuccessScreenWrapper>

--- a/packages/extension/src/ui/utils/tokens.ts
+++ b/packages/extension/src/ui/utils/tokens.ts
@@ -1,10 +1,11 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { ethers } from "ethers"
 import mitt from "mitt"
-import { Abi, Contract, Provider, encode, shortString, uint256 } from "starknet"
+import { Abi, Contract, encode, shortString, uint256 } from "starknet"
 
 import parsedErc20Abi from "../../abi/ERC20.json"
 import erc20Tokens from "../../assets/erc20-tokens.json"
+import { getProvider } from "../../shared/networks"
 import { isValidAddress } from "./addresses"
 
 export const playgroundToken = (networkId: string) =>
@@ -101,7 +102,7 @@ export const fetchTokenDetails = async (
   walletAddress: string,
   networkId: string,
 ): Promise<TokenDetails> => {
-  const provider = new Provider({ network: networkId as any })
+  const provider = getProvider(networkId)
   const tokenContract = new Contract(parsedErc20Abi as Abi[], address, provider)
   const [decimals, name, balance, symbol] = await Promise.all([
     tokenContract

--- a/packages/extension/src/ui/utils/wallet.ts
+++ b/packages/extension/src/ui/utils/wallet.ts
@@ -29,10 +29,12 @@ export const isWalletDeployed = (wallet: Wallet): boolean =>
   !wallet.deployTransaction
 
 export type WalletStatusCode = "CONNECTED" | "DEFAULT" | "DEPLOYING"
+
 export interface WalletStatus {
   code: WalletStatusCode
   text: string
 }
+
 export const getStatus = (
   wallet: Wallet,
   activeWalletAddress?: string,

--- a/packages/playground/src/components/TokenDapp.tsx
+++ b/packages/playground/src/components/TokenDapp.tsx
@@ -35,13 +35,28 @@ export const TokenDapp: FC = () => {
     })()
   }, [transactionStatus, lastTransactionHash])
 
+  const network = networkId()
+  if (network !== "goerli-alpha" && network !== "mainnet-alpha") {
+    return (
+      <>
+        <p>
+          There is no demo token for this network, but you can deploy one and
+          add its address to this file:
+        </p>
+        <div>
+          <pre>packages/playground/src/token.service.ts</pre>
+        </div>
+      </>
+    )
+  }
+
   const handleMintSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
       setTransactionStatus("approve")
 
       console.log("mint", mintAmount)
-      const result = await mintToken(mintAmount, networkId())
+      const result = await mintToken(mintAmount, network)
       console.log(result)
 
       setLastTransactionHash(result.transaction_hash)
@@ -58,7 +73,7 @@ export const TokenDapp: FC = () => {
       setTransactionStatus("approve")
 
       console.log("transfer", { transferTo, transferAmount })
-      const result = await transfer(transferTo, transferAmount, networkId())
+      const result = await transfer(transferTo, transferAmount, network)
       console.log(result)
 
       setLastTransactionHash(result.transaction_hash)
@@ -85,6 +100,8 @@ export const TokenDapp: FC = () => {
       setTransactionStatus("idle")
     }
   }
+
+  const tokenAddress = getErc20TokenAddress(network)
 
   return (
     <>
@@ -184,12 +201,10 @@ export const TokenDapp: FC = () => {
         <code>
           <a
             target="_blank"
-            href={`${getExplorerUrlBase()}/contract/${getErc20TokenAddress(
-              networkId(),
-            )}`}
+            href={`${getExplorerUrlBase()}/contract/${tokenAddress}`}
             rel="noreferrer"
           >
-            {getErc20TokenAddress(networkId())}
+            {tokenAddress}
           </a>
         </code>
       </h3>

--- a/packages/playground/src/services/token.service.ts
+++ b/packages/playground/src/services/token.service.ts
@@ -9,9 +9,11 @@ export const erc20TokenAddressByNetwork = {
     "0x06a09ccb1caaecf3d9683efe335a667b2169a409d19c589ba1eb771cd210af75",
 }
 
-export const getErc20TokenAddress = (
-  network: keyof typeof erc20TokenAddressByNetwork,
-) => erc20TokenAddressByNetwork[network]
+export type PublicNetwork = keyof typeof erc20TokenAddressByNetwork
+export type Network = PublicNetwork | "localhost"
+
+export const getErc20TokenAddress = (network: PublicNetwork) =>
+  erc20TokenAddressByNetwork[network]
 
 const mintSelector = stark.getSelectorFromName("mint")
 

--- a/packages/playground/src/services/wallet.service.ts
+++ b/packages/playground/src/services/wallet.service.ts
@@ -1,7 +1,7 @@
 import { getStarknet } from "@argent/get-starknet"
 import { shortString } from "starknet"
 
-import { erc20TokenAddressByNetwork } from "./token.service"
+import { Network } from "./token.service"
 
 export const isWalletConnected = (): boolean => !!getStarknet()?.isConnected
 
@@ -15,23 +15,23 @@ export const walletAddress = async (): Promise<string | undefined> => {
   } catch {}
 }
 
-export const networkId = (): keyof typeof erc20TokenAddressByNetwork => {
+export const networkId = (): Network | undefined => {
   try {
-    const baseUrl = getStarknet().provider.baseUrl
+    const { baseUrl } = getStarknet().provider
     if (baseUrl.includes("alpha-mainnet.starknet.io")) {
       return "mainnet-alpha"
-    } else {
+    } else if (baseUrl.includes("alpha4.starknet.io")) {
       return "goerli-alpha"
+    } else if (baseUrl.match(/^https?:\/\/localhost.*/)) {
+      return "localhost"
     }
-  } catch {
-    return "goerli-alpha"
-  }
+  } catch {}
 }
 
-export const getExplorerUrlBase = (): string => {
+export const getExplorerUrlBase = (): string | undefined => {
   if (networkId() === "mainnet-alpha") {
     return "https://voyager.online"
-  } else {
+  } else if (networkId() === "goerli-alpha") {
     return "https://goerli.voyager.online"
   }
 }


### PR DESCRIPTION
Rudimentary implementation of local network support with:

- Addition of a `localhost` network whose port number can be changed in settings.
- Backup of wallets on custom networks by allowing urls in lieu of network ids.
- Update of playground page for the case where there is no known token to play with.

/!\ This PR likely shouldn't be part of a release without proper handling of errors, checking existence of wallets on networks, etc beforehand. /!\