### PR TITLE
fix: mainnet tx status update

### DIFF
--- a/packages/extension/src/ui/hooks/useStatus.ts
+++ b/packages/extension/src/ui/hooks/useStatus.ts
@@ -1,16 +1,19 @@
 import { useEffect, useState } from "react"
-import { defaultProvider } from "starknet"
+import { Provider, defaultProvider } from "starknet"
 
 import { getStatus } from "../utils/wallet"
 import { Wallet } from "../Wallet"
 
 type Status = "PENDING" | "SUCCESS" | "ERROR" | "SKIPED"
-export const useTxStatus = (txHash?: string): Status => {
+export const useTxStatus = (
+  txHash?: string,
+  provider: Provider = defaultProvider,
+): Status => {
   const [txStatus, setTxStatus] = useState<Status>("PENDING")
 
   useEffect(() => {
     if (txHash)
-      defaultProvider
+      provider
         .waitForTx(txHash)
         .then(() => {
           setTxStatus("SUCCESS")
@@ -24,7 +27,10 @@ export const useTxStatus = (txHash?: string): Status => {
 }
 
 export const useStatus = (wallet: Wallet, activeWalletAddress?: string) => {
-  const deployStatus = useTxStatus(wallet.deployTransaction)
+  const deployStatus = useTxStatus(
+    wallet.deployTransaction,
+    wallet.contract.provider,
+  )
 
   useEffect(() => {
     if (deployStatus === "SUCCESS") wallet.completeDeployTx()


### PR DESCRIPTION
This fixes an issue where wallet deployment transactions where checked against the default provider instead of the wallet provider which could result in a network mismatch and therefore the wallet never shows as deployed