### PR TITLE
feat: show pending transactions

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -83,6 +83,20 @@ async function main() {
         return openUi()
       }
 
+      case "GET_TRANSACTIONS": {
+        const selectedWallet = await selectedWalletStore.getItem(
+          "SELECTED_WALLET",
+        )
+        const transactions = transactionTracker.getAllTransactions(
+          selectedWallet.address,
+        )
+
+        return sendToTabAndUi({
+          type: "GET_TRANSACTIONS_RES",
+          data: transactions,
+        })
+      }
+
       case "GET_TRANSACTION": {
         const cached = transactionTracker.getTransactionStatus(msg.data.hash)
         if (cached) {
@@ -199,7 +213,7 @@ async function main() {
 
             transactionTracker.trackTransaction(
               tx.transaction_hash,
-              selectedWallet.network,
+              selectedWallet,
             )
 
             return sendToTabAndUi({
@@ -372,7 +386,9 @@ async function main() {
 
         const wallet = { address: newAccount.address, network }
         selectedWalletStore.setItem("SELECTED_WALLET", wallet)
-        transactionTracker.trackTransaction(newAccount.txHash, network)
+        transactionTracker.trackTransaction(newAccount.txHash, wallet, {
+          title: "Deploy wallet",
+        })
 
         return sendToTabAndUi({ type: "NEW_ACCOUNT_RES", data: newAccount })
       }

--- a/packages/extension/src/background/trackTransactions.ts
+++ b/packages/extension/src/background/trackTransactions.ts
@@ -1,22 +1,30 @@
 import { Provider, Status } from "starknet"
 
-interface TransactionStatus {
-  hash: string
-  status: Status
+import { BackupWallet } from "../shared/backup.model"
+import {
+  TransactionMeta,
+  TransactionStatus,
+} from "../shared/transactions.model"
+
+interface TransactionStatusWithProvider extends TransactionStatus {
+  provider: Provider
 }
+type FetchedTransactionStatus = Omit<
+  Omit<TransactionStatus, "walletAddress">,
+  "meta"
+>
 type Listener = (transactions: TransactionStatus[]) => void
 
 export async function getTransactionStatus(
   provider: Provider,
   hash: string,
-): Promise<TransactionStatus> {
+): Promise<FetchedTransactionStatus> {
   const { tx_status } = await provider.getTransactionStatus(hash)
   return { hash, status: tx_status }
 }
 
 export class TransactionTracker {
-  private transactions: { hash: string; provider: Provider }[] = []
-  private transactionStatus: TransactionStatus[] = []
+  private transactions: TransactionStatusWithProvider[] = []
   private listeners: Listener[] = []
   private interval: NodeJS.Timeout
 
@@ -27,24 +35,56 @@ export class TransactionTracker {
 
   public async trackTransaction(
     transactionHash: string,
-    network: string,
+    wallet: BackupWallet,
+    meta: TransactionMeta = {
+      title: "Contract interaction",
+    },
   ): Promise<void> {
-    const provider = new Provider({ network: network as any })
-    this.transactions.push({ hash: transactionHash, provider })
+    const provider = new Provider({ network: wallet.network as any })
+    this.transactions.push({
+      hash: transactionHash,
+      provider,
+      walletAddress: wallet.address,
+      status: "RECEIVED",
+      meta,
+    })
+
+    this.listeners.forEach((listener) => {
+      listener(this.transactions)
+    })
+  }
+
+  public getAllTransactions(byWalletAddress?: string): TransactionStatus[] {
+    return this.transactions
+      .filter(
+        (transaction) =>
+          !byWalletAddress || transaction.walletAddress === byWalletAddress,
+      )
+      .map(({ hash, walletAddress, meta }) => ({
+        hash,
+        walletAddress,
+        status: this.getTransactionStatus(hash)?.status || "NOT_RECEIVED",
+        meta,
+      }))
   }
 
   public getTransactionStatus(hash: string): TransactionStatus | undefined {
-    return this.transactionStatus.find(({ hash: txHash }) => txHash === hash)
+    return this.transactions.find(({ hash: txHash }) => txHash === hash)
   }
 
   private async checkTransactions(): Promise<void> {
     const transactionStatus = await Promise.all(
-      this.transactions.map(async ({ hash, provider }) => {
-        return getTransactionStatus(provider, hash)
+      this.transactions.map(async ({ hash, provider, walletAddress, meta }) => {
+        return getTransactionStatus(provider, hash).then((status) => ({
+          ...status,
+          walletAddress,
+          provider,
+          meta,
+        }))
       }),
     )
     if (transactionStatus.length > 0) {
-      this.transactionStatus = transactionStatus
+      this.transactions = transactionStatus
       this.listeners.forEach((listener) => {
         listener(transactionStatus)
       })

--- a/packages/extension/src/background/trackTransactions.ts
+++ b/packages/extension/src/background/trackTransactions.ts
@@ -10,9 +10,10 @@ interface TransactionStatusWithProvider extends TransactionStatus {
   provider: Provider
 }
 type FetchedTransactionStatus = Omit<
-  Omit<TransactionStatus, "walletAddress">,
-  "meta"
+  TransactionStatus,
+  "walletAddress" | "meta"
 >
+
 type Listener = (transactions: TransactionStatus[]) => void
 
 export async function getTransactionStatus(

--- a/packages/extension/src/shared/MessageType.ts
+++ b/packages/extension/src/shared/MessageType.ts
@@ -1,17 +1,18 @@
 import type { JWK } from "jose"
-import type { InvokeFunctionTransaction, Status, typedData } from "starknet"
+import type { InvokeFunctionTransaction, typedData } from "starknet"
 
 import { ExtActionItem } from "./actionQueue"
 import { BackupWallet } from "./backup.model"
 import { AddToken } from "./token.model"
+import { TransactionStatus } from "./transactions.model"
 
 export type MessageType =
   | { type: "OPEN_UI" }
   | { type: "ADD_TRANSACTION"; data: InvokeFunctionTransaction }
   | { type: "ADD_TRANSACTION_RES"; data: { actionHash: string } }
-  | { type: "TRANSACTION_UPDATES"; data: { hash: string; status: Status }[] }
+  | { type: "TRANSACTION_UPDATES"; data: TransactionStatus[] }
   | { type: "GET_TRANSACTION"; data: { hash: string; network: string } }
-  | { type: "GET_TRANSACTION_RES"; data: { hash: string; status: Status } }
+  | { type: "GET_TRANSACTION_RES"; data: TransactionStatus }
   | { type: "GET_ACTIONS" }
   | {
       type: "GET_ACTIONS_RES"
@@ -81,6 +82,8 @@ export type MessageType =
     }
   | { type: "FAILED_SIGN"; data: { actionHash: string } }
   | { type: "SUCCESS_SIGN"; data: { r: string; s: string; actionHash: string } }
+  | { type: "GET_TRANSACTIONS" }
+  | { type: "GET_TRANSACTIONS_RES"; data: TransactionStatus[] }
 
 export type WindowMessageType = {
   forwarded?: boolean

--- a/packages/extension/src/shared/transactions.model.ts
+++ b/packages/extension/src/shared/transactions.model.ts
@@ -1,0 +1,12 @@
+import { Status } from "starknet"
+
+export interface TransactionMeta {
+  title: string
+}
+
+export interface TransactionStatus {
+  hash: string
+  walletAddress?: string
+  status: Status
+  meta?: TransactionMeta
+}

--- a/packages/extension/src/ui/components/Account/AccountSubheader.tsx
+++ b/packages/extension/src/ui/components/Account/AccountSubheader.tsx
@@ -5,7 +5,7 @@ import Copy from "../../../assets/copy.svg"
 import Open from "../../../assets/open.svg"
 import { getNetwork } from "../../../shared/networks"
 import { truncateAddress } from "../../utils/addresses"
-import { WalletStatus, getAccountName } from "../../utils/wallet"
+import { WalletStatus, formatAddress, getAccountName } from "../../utils/wallet"
 import { CopyTooltip } from "../CopyTooltip"
 import { H1 } from "../Typography"
 import {
@@ -57,7 +57,7 @@ export const AccountSubHeader: FC<AccountSubheaderProps> = ({
         {truncateAddress(walletAddress)}
         <Open />
       </AccountAddressLink>
-      <CopyTooltip copyValue={walletAddress} message="Copied!">
+      <CopyTooltip copyValue={formatAddress(walletAddress)} message="Copied!">
         <AccountAddressIconsWrapper>
           <Copy />
         </AccountAddressIconsWrapper>

--- a/packages/extension/src/ui/components/Account/EmptyWalletAlert.tsx
+++ b/packages/extension/src/ui/components/Account/EmptyWalletAlert.tsx
@@ -3,7 +3,7 @@ import { FC } from "react"
 import styled from "styled-components"
 
 import { makeClickable } from "../../utils/a11y"
-import { playgroundToken } from "../../utils/tokens"
+import { formatAddress } from "../../utils/wallet"
 import { Alert } from "../Alert"
 import { Button } from "../Button"
 import { CopyTooltip } from "../CopyTooltip"
@@ -11,6 +11,7 @@ import { TokenAction } from "../Token"
 
 const AlertWrapper = styled(Alert)`
   gap: 16px;
+  margin: 16px 20px;
 `
 
 const Title = styled.h2`
@@ -53,7 +54,7 @@ export const EmptyWalletAlert: FC<EmptyWalletAlertProps> = ({
     </Paragraph>
     <Buttons>
       <CopyTooltip
-        copyValue={`starknet:${walletAddress}`}
+        copyValue={formatAddress(walletAddress)}
         message="Wallet address copied!"
       >
         <AlertButton>Receive</AlertButton>

--- a/packages/extension/src/ui/components/Account/SectionHeader.tsx
+++ b/packages/extension/src/ui/components/Account/SectionHeader.tsx
@@ -1,0 +1,8 @@
+import styled from "styled-components"
+
+export const SectionHeader = styled.h3`
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 20px;
+  margin: 0;
+`

--- a/packages/extension/src/ui/components/Account/TokenList.tsx
+++ b/packages/extension/src/ui/components/Account/TokenList.tsx
@@ -13,7 +13,6 @@ import {
 import { TokenAction, TokenListItem } from "../Token"
 import { EmptyWalletAlert } from "./EmptyWalletAlert"
 import { SectionHeader } from "./SectionHeader"
-import { TransactionIndicator } from "./Transactions"
 
 interface TokenListProps {
   networkId: string
@@ -22,11 +21,6 @@ interface TokenListProps {
   onShowToken: (token: TokenDetails) => void
   onAction?: (token: string, action: TokenAction) => Promise<void> | void
 }
-
-const UpdateIndicator = styled(TransactionIndicator)<{ hide: boolean }>`
-  transition: all 200ms ease-in-out;
-  opacity: ${({ hide }) => (hide ? 0 : 1)};
-`
 
 export const TokenList: FC<TokenListProps> = ({
   networkId,
@@ -67,15 +61,13 @@ export const TokenList: FC<TokenListProps> = ({
           onAction={onAction}
         />
       )}
-      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
-        <SectionHeader>Coins</SectionHeader>
-        <UpdateIndicator status="DEPLOYING" hide={!isValidating} />
-      </div>
+      <SectionHeader>Coins</SectionHeader>
       {tokenDetails.map((token) => (
         <TokenListItem
           key={token.address}
           token={token}
           onClick={() => onShowToken(token)}
+          isLoading={isValidating}
         />
       ))}
     </>

--- a/packages/extension/src/ui/components/Account/TokenList.tsx
+++ b/packages/extension/src/ui/components/Account/TokenList.tsx
@@ -1,4 +1,5 @@
 import { FC } from "react"
+import styled, { css } from "styled-components"
 import useSWR from "swr"
 
 import { useMitt } from "../../hooks/useMitt"
@@ -11,17 +12,26 @@ import {
 } from "../../utils/tokens"
 import { TokenAction, TokenListItem } from "../Token"
 import { EmptyWalletAlert } from "./EmptyWalletAlert"
+import { SectionHeader } from "./SectionHeader"
+import { TransactionIndicator } from "./Transactions"
 
 interface TokenListProps {
   networkId: string
   walletAddress: string
+  canShowEmptyWalletAlert?: boolean
   onShowToken: (token: TokenDetails) => void
   onAction?: (token: string, action: TokenAction) => Promise<void> | void
 }
 
+const UpdateIndicator = styled(TransactionIndicator)<{ hide: boolean }>`
+  transition: all 200ms ease-in-out;
+  opacity: ${({ hide }) => (hide ? 0 : 1)};
+`
+
 export const TokenList: FC<TokenListProps> = ({
   networkId,
   walletAddress,
+  canShowEmptyWalletAlert = true,
   onShowToken,
   onAction,
 }) => {
@@ -32,7 +42,7 @@ export const TokenList: FC<TokenListProps> = ({
     true,
   )
 
-  const { data: tokenDetails = [] } = useSWR(
+  const { data: tokenDetails = [], isValidating } = useSWR(
     [tokens, walletAddress],
     async (tokens, walletAddress) =>
       Promise.all(
@@ -50,13 +60,17 @@ export const TokenList: FC<TokenListProps> = ({
 
   return (
     <>
-      {!hasBalance && (
+      {canShowEmptyWalletAlert && !hasBalance && (
         <EmptyWalletAlert
           walletAddress={walletAddress}
           mintableAddress={playgroundToken(networkId)?.address}
           onAction={onAction}
         />
       )}
+      <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        <SectionHeader>Coins</SectionHeader>
+        <UpdateIndicator status="DEPLOYING" hide={!isValidating} />
+      </div>
       {tokenDetails.map((token) => (
         <TokenListItem
           key={token.address}

--- a/packages/extension/src/ui/components/Account/Transactions.tsx
+++ b/packages/extension/src/ui/components/Account/Transactions.tsx
@@ -1,0 +1,98 @@
+import { FC } from "react"
+import styled, { css, keyframes } from "styled-components"
+
+import { TransactionMeta as ITransactionMeta } from "../../../shared/transactions.model"
+// import { makeClickable } from "../../utils/a11y"
+import { truncateAddress } from "../../utils/addresses"
+import { CopyTooltip } from "../CopyTooltip"
+import { NetworkStatusIndicator } from "../NetworkSwitcher"
+import {
+  TokenDetailsWrapper,
+  TokenMeta,
+  TokenTextGroup,
+  TokenTitle,
+  TokenWrapper,
+} from "../Token"
+import { TokenIcon } from "../TokenIcon"
+
+export const TransactionsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: #333332;
+  border-radius: 8px;
+  padding: 16px;
+`
+
+const TransactionWrapper = styled(TokenWrapper)`
+  background-color: #333332;
+  cursor: auto;
+
+  &:hover,
+  &:focus {
+    background-color: #333332;
+  }
+`
+
+const PulseAnimation = keyframes`
+	0% {
+		transform: scale(0.95);
+		box-shadow: 0 0 0 0 rgba(255, 168, 92, 0.7);
+	}
+
+	70% {
+		transform: scale(1);
+		box-shadow: 0 0 0 6px rgba(255, 168, 92, 0);
+	}
+
+	100% {
+		transform: scale(0.95);
+		box-shadow: 0 0 0 0 rgba(255, 168, 92, 0);
+	}
+`
+
+export const TransactionIndicator = styled(NetworkStatusIndicator)`
+  margin-right: 8px;
+
+  ${({ status = "CONNECTED" }) =>
+    status === "DEPLOYING" &&
+    css`
+      box-shadow: 0 0 0 0 rgba(255, 168, 92, 1);
+      transform: scale(1);
+      animation: ${PulseAnimation} 1.5s infinite;
+    `}
+`
+
+const TransactionMeta = styled(TokenMeta)`
+  cursor: pointer;
+`
+
+interface TransactionProps {
+  txHash: string
+  meta?: ITransactionMeta
+  onClick?: () => void
+}
+
+export const TransactionItem: FC<TransactionProps> = ({
+  txHash,
+  meta,
+  onClick,
+  ...props
+}) => {
+  return (
+    <TransactionWrapper
+      // {...makeClickable(onClick)} // TODO: can be reenabled once voyager supports pending transactions
+      {...props}
+    >
+      <TokenIcon name={meta?.title || txHash.substring(2)} />
+      <TokenDetailsWrapper>
+        <TokenTextGroup>
+          <TokenTitle>{meta?.title || truncateAddress(txHash)}</TokenTitle>
+          <CopyTooltip copyValue={txHash} message="Transaction hash copied!">
+            <TransactionMeta>{truncateAddress(txHash)}</TransactionMeta>
+          </CopyTooltip>
+        </TokenTextGroup>
+        <TransactionIndicator status={"DEPLOYING"} />
+      </TokenDetailsWrapper>
+    </TransactionWrapper>
+  )
+}

--- a/packages/extension/src/ui/components/Account/Transactions.tsx
+++ b/packages/extension/src/ui/components/Account/Transactions.tsx
@@ -2,7 +2,6 @@ import { FC } from "react"
 import styled, { css, keyframes } from "styled-components"
 
 import { TransactionMeta as ITransactionMeta } from "../../../shared/transactions.model"
-// import { makeClickable } from "../../utils/a11y"
 import { truncateAddress } from "../../utils/addresses"
 import { CopyTooltip } from "../CopyTooltip"
 import { NetworkStatusIndicator } from "../NetworkSwitcher"
@@ -34,20 +33,20 @@ const TransactionWrapper = styled(TokenWrapper)`
 `
 
 const PulseAnimation = keyframes`
-	0% {
-		transform: scale(0.95);
-		box-shadow: 0 0 0 0 rgba(255, 168, 92, 0.7);
-	}
+  0% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(255, 168, 92, 0.7);
+  }
 
-	70% {
-		transform: scale(1);
-		box-shadow: 0 0 0 6px rgba(255, 168, 92, 0);
-	}
+  70% {
+    transform: scale(1);
+    box-shadow: 0 0 0 6px rgba(255, 168, 92, 0);
+  }
 
-	100% {
-		transform: scale(0.95);
-		box-shadow: 0 0 0 0 rgba(255, 168, 92, 0);
-	}
+  100% {
+    transform: scale(0.95);
+    box-shadow: 0 0 0 0 rgba(255, 168, 92, 0);
+  }
 `
 
 export const TransactionIndicator = styled(NetworkStatusIndicator)`

--- a/packages/extension/src/ui/components/CopyTooltip.tsx
+++ b/packages/extension/src/ui/components/CopyTooltip.tsx
@@ -1,5 +1,5 @@
 import Tippy from "@tippyjs/react"
-import { FC, useState } from "react"
+import { FC, useEffect, useRef, useState } from "react"
 import CopyToClipboard from "react-copy-to-clipboard"
 import styled from "styled-components"
 
@@ -14,20 +14,37 @@ export const Tooltip = styled.span`
 interface CopyTooltipProps {
   copyValue: string
   message: string
+  autoDismiss?: boolean
 }
 
 export const CopyTooltip: FC<CopyTooltipProps> = ({
   copyValue,
   message,
+  autoDismiss = true,
   children,
 }) => {
   const [visible, setVisible] = useState(false)
+  const pidRef = useRef<any>()
+
+  useEffect(() => {
+    if (autoDismiss && visible) {
+      pidRef.current = setTimeout(() => setVisible(false), 2500)
+    }
+    return () => {
+      clearTimeout(pidRef.current)
+    }
+  }, [autoDismiss, visible])
 
   return (
     <Tippy
       visible={visible}
       content={<Tooltip>{message}</Tooltip>}
-      onClickOutside={() => setVisible(false)}
+      onClickOutside={() => {
+        if (pidRef.current) {
+          clearTimeout(pidRef.current)
+        }
+        setVisible(false)
+      }}
     >
       <div>
         <CopyToClipboard text={copyValue} onCopy={() => setVisible(true)}>

--- a/packages/extension/src/ui/components/Token.tsx
+++ b/packages/extension/src/ui/components/Token.tsx
@@ -13,6 +13,7 @@ export const TokenWrapper = styled.div`
   gap: 16px;
   padding: 8px;
   cursor: pointer;
+  border-radius: 4px;
 
   transition: all 200ms ease-in-out;
 
@@ -23,14 +24,14 @@ export const TokenWrapper = styled.div`
   }
 `
 
-const TokenDetailsWrapper = styled.div`
+export const TokenDetailsWrapper = styled.div`
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
 `
 
-const TokenTextGroup = styled.div`
+export const TokenTextGroup = styled.div`
   display: flex;
   flex-direction: column;
 `
@@ -42,14 +43,14 @@ export const TokenTitle = styled.h3`
   margin: 0;
 `
 
-const TokenMeta = styled.p`
+export const TokenMeta = styled.p`
   font-size: 13px;
   line-height: 18px;
   color: #8f8e8c;
   margin: 0;
 `
 
-const TokenBalance = styled.p`
+export const TokenBalance = styled.p`
   font-weight: 600;
   font-size: 17px;
   line-height: 22px;
@@ -83,17 +84,15 @@ export const TokenListItem: FC<TokenListItemProps> = ({
 }) => {
   const { name, symbol, balance } = toTokenView(token)
   return (
-    <div {...props} style={{ borderRadius: 4, overflow: "hidden" }}>
-      <TokenWrapper {...makeClickable(onClick)}>
-        <TokenIcon name={name} />
-        <TokenDetailsWrapper>
-          <TokenTextGroup>
-            <TokenTitle>{symbol}</TokenTitle>
-            <TokenMeta>{name}</TokenMeta>
-          </TokenTextGroup>
-          <TokenBalance>{balance}</TokenBalance>
-        </TokenDetailsWrapper>
-      </TokenWrapper>
-    </div>
+    <TokenWrapper {...makeClickable(onClick)} {...props}>
+      <TokenIcon name={name} />
+      <TokenDetailsWrapper>
+        <TokenTextGroup>
+          <TokenTitle>{symbol}</TokenTitle>
+          <TokenMeta>{name}</TokenMeta>
+        </TokenTextGroup>
+        <TokenBalance>{balance}</TokenBalance>
+      </TokenDetailsWrapper>
+    </TokenWrapper>
   )
 }

--- a/packages/extension/src/ui/components/Token.tsx
+++ b/packages/extension/src/ui/components/Token.tsx
@@ -1,6 +1,6 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { FC } from "react"
-import styled from "styled-components"
+import styled, { css, keyframes } from "styled-components"
 
 import { makeClickable } from "../utils/a11y"
 import { TokenDetails, toTokenView } from "../utils/tokens"
@@ -50,7 +50,21 @@ export const TokenMeta = styled.p`
   margin: 0;
 `
 
-export const TokenBalance = styled.p`
+const PulseAnimation = keyframes`
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
+  }
+`
+
+export const TokenBalance = styled.p<{
+  isLoading?: boolean
+}>`
   font-weight: 600;
   font-size: 17px;
   line-height: 22px;
@@ -58,6 +72,13 @@ export const TokenBalance = styled.p`
   max-width: 64px;
   overflow: hidden;
   white-space: nowrap;
+
+  opacity: 1;
+  ${({ isLoading }) =>
+    isLoading &&
+    css`
+      animation: ${PulseAnimation} 1.5s ease-in-out infinite;
+    `}
 `
 
 export const AddTokenIconButton = styled(IconButton)`
@@ -74,11 +95,13 @@ export type TokenAction =
 
 interface TokenListItemProps {
   token: TokenDetails
+  isLoading?: boolean
   onClick?: () => void
 }
 
 export const TokenListItem: FC<TokenListItemProps> = ({
   token,
+  isLoading = false,
   onClick,
   ...props
 }) => {
@@ -91,7 +114,7 @@ export const TokenListItem: FC<TokenListItemProps> = ({
           <TokenTitle>{symbol}</TokenTitle>
           <TokenMeta>{name}</TokenMeta>
         </TokenTextGroup>
-        <TokenBalance>{balance}</TokenBalance>
+        <TokenBalance isLoading={isLoading}>{balance}</TokenBalance>
       </TokenDetailsWrapper>
     </TokenWrapper>
   )

--- a/packages/extension/src/ui/states/RouterMachine.ts
+++ b/packages/extension/src/ui/states/RouterMachine.ts
@@ -329,6 +329,8 @@ export const createRouterMachine = (closeAfterActions?: boolean) =>
 
             const newWallet = await Wallet.fromDeploy(ctx.networkId)
 
+            useProgress.setState({ progress: 0, text: "" })
+
             return {
               newWallet,
             }

--- a/packages/extension/src/ui/states/actions.ts
+++ b/packages/extension/src/ui/states/actions.ts
@@ -40,13 +40,17 @@ export const useActions = () => {
   useEffect(() => {
     useActionsStore.setState({ actions })
 
-    const { unsubscribe } = messageStream.subscribe(([message]) => {
+    const listener = messageStream.subscribe(([message]) => {
       if (message.type === "ACTIONS_QUEUE_UPDATE") {
         useActionsStore.setState({ actions: message.data.actions })
       }
     })
 
-    return unsubscribe
+    return () => {
+      if (!listener.closed) {
+        listener.unsubscribe()
+      }
+    }
   }, [])
 
   return useActionsStore()

--- a/packages/extension/src/ui/states/walletTransactions.ts
+++ b/packages/extension/src/ui/states/walletTransactions.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react"
+import create from "zustand"
+
+import { messageStream } from "../../shared/messages"
+import { TransactionStatus } from "../../shared/transactions.model"
+import { getTransactions } from "../utils/messaging"
+
+interface TransactionsStore {
+  transactions: TransactionStatus[]
+}
+
+const useTransactionsStore = create<TransactionsStore>(() => ({
+  transactions: [],
+}))
+
+export const useWalletTransactions = (walletAddress: string) => {
+  useEffect(() => {
+    getTransactions().then((transactions) => {
+      useTransactionsStore.setState({ transactions })
+    })
+
+    const listener = messageStream.subscribe(([message]) => {
+      if (message.type === "TRANSACTION_UPDATES") {
+        useTransactionsStore.setState({
+          transactions: message.data.filter(
+            ({ walletAddress: wa }) => wa === walletAddress,
+          ),
+        })
+      }
+    })
+
+    return () => {
+      if (!listener.closed) {
+        listener.unsubscribe()
+      }
+    }
+  }, [])
+
+  return useTransactionsStore((x) => x.transactions)
+}

--- a/packages/extension/src/ui/utils/messaging.ts
+++ b/packages/extension/src/ui/utils/messaging.ts
@@ -18,6 +18,11 @@ export const getActions = async () => {
   return waitForMessage("GET_ACTIONS_RES")
 }
 
+export const getTransactions = async () => {
+  sendMessage({ type: "GET_TRANSACTIONS" })
+  return waitForMessage("GET_TRANSACTIONS_RES")
+}
+
 export const getTransactionStatus = async (hash: string, network: string) => {
   sendMessage({ type: "GET_TRANSACTION", data: { hash, network } })
   return waitForMessage("GET_TRANSACTION_RES", (x) => x.data.hash === hash)

--- a/packages/extension/src/ui/utils/wallet.ts
+++ b/packages/extension/src/ui/utils/wallet.ts
@@ -1,3 +1,5 @@
+import { encode } from "starknet"
+
 import type { Wallet } from "../Wallet"
 
 const argentColorsArray = [
@@ -10,6 +12,10 @@ const argentColorsArray = [
   "FF675C",
   "FF5C72",
 ]
+
+export const formatAddress = (address: string) =>
+  // encode.addHexPrefix(encode.removeHexPrefix(address).padStart(64, "0")) // should we pad the address?
+  encode.addHexPrefix(address)
 
 export const getAccountColor = (accountNumber: number, withPrefix = true) =>
   `${withPrefix ? "#" : ""}${


### PR DESCRIPTION
this PR adds support for pending transactions and shows them. 

It also adds some other improvements:
- Indicator is shown when token balances update in the background (swr)
- when signing something the extension shows a loading screen after approving until the transaction was broadcasted