### PR TITLE
feat: transaction queueing

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -217,10 +217,7 @@ async function main() {
 
             const nonce = await getNonce(signer)
 
-            const tx = await signer.addTransaction({
-              ...transaction,
-              nonce: nonce,
-            })
+            const tx = await signer.addTransaction({ ...transaction, nonce })
 
             increaseStoredNonce(signer.address)
             transactionTracker.trackTransaction(

--- a/packages/extension/src/background/nonce.ts
+++ b/packages/extension/src/background/nonce.ts
@@ -1,0 +1,39 @@
+import { Signer, number, stark } from "starknet"
+
+const nonceStore: {
+  [walletAddress: string]: string
+} = {}
+
+export async function getNonce(signer: Signer): Promise<string> {
+  const { result } = await signer.callContract({
+    contract_address: signer.address,
+    entry_point_selector: stark.getSelectorFromName("get_nonce"),
+  })
+  const nonceBn = number.toBN(result[0])
+  const storedNonce = nonceStore[signer.address]
+
+  // If the stored nonce is not equal to the current nonce, store the current nonce
+  if (!storedNonce || !nonceBn.eq(number.toBN(storedNonce))) {
+    nonceStore[signer.address] = number.toHex(nonceBn)
+  }
+
+  // If the stored nonce is greater than the current nonce, use the stored nonce
+  if (storedNonce && nonceBn.lt(number.toBN(storedNonce))) {
+    return number.toHex(number.toBN(storedNonce))
+  }
+
+  return number.toHex(nonceBn)
+}
+
+export function increaseStoredNonce(address: string): void {
+  const currentNonce = nonceStore[address]
+  if (currentNonce) {
+    nonceStore[address] = number.toHex(
+      number.toBN(currentNonce).add(number.toBN(1)),
+    )
+  }
+}
+
+export function resetStoredNonce(address: string): void {
+  delete nonceStore[address]
+}

--- a/packages/extension/src/background/nonce.ts
+++ b/packages/extension/src/background/nonce.ts
@@ -1,8 +1,6 @@
 import { Signer, number, stark } from "starknet"
 
-const nonceStore: {
-  [walletAddress: string]: string
-} = {}
+const nonceStore: Record<string, string> = {}
 
 export async function getNonce(signer: Signer): Promise<string> {
   const { result } = await signer.callContract({

--- a/packages/extension/src/background/notification.ts
+++ b/packages/extension/src/background/notification.ts
@@ -1,6 +1,7 @@
 import { Status } from "starknet"
 import browser from "webextension-polyfill"
 
+import { TransactionMeta } from "../shared/transactions.model"
 import { Storage } from "./storage"
 
 const notificationsStorage = new Storage({
@@ -10,9 +11,12 @@ const notificationsStorage = new Storage({
 export async function sentTransactionNotification(
   hash: string,
   status: Status,
+  meta?: TransactionMeta,
 ) {
   const id = `TX:${hash}`
-  const displayedText = status === "ACCEPTED_ON_L2" ? "succeeded" : "rejected"
+  const title = `${meta?.title || "Transaction"} ${
+    status === "ACCEPTED_ON_L2" ? "succeeded" : "rejected"
+  }`
   const alreadyShownTransactions = await notificationsStorage.getItem(
     "notificationsShown",
   )
@@ -23,8 +27,8 @@ export async function sentTransactionNotification(
     ])
     return browser.notifications.create(id, {
       type: "basic",
-      title: `Transaction ${displayedText}`,
-      message: `Transaction: ${hash} \nStatus: ${status}`,
+      title,
+      message: `${hash}\nStatus: ${status}`,
       iconUrl: "./assets/logo.png",
       eventTime: Date.now(),
     })


### PR DESCRIPTION
Allows wallets to queue multiple transactions into one block, by increasing the nonce optimistically.
If one transaction fails all subsequent transactions will also fail (nonce mismatch)