### PR TITLE
feat: decrease load on sequencer

### DIFF
--- a/packages/extension/src/background/trackTransactions.ts
+++ b/packages/extension/src/background/trackTransactions.ts
@@ -81,14 +81,27 @@ export class TransactionTracker {
 
   private async checkTransactions(): Promise<void> {
     const transactionStatuses = await Promise.all(
-      this.transactions.map(async ({ hash, provider, walletAddress, meta }) => {
-        return getTransactionStatus(provider, hash).then((status) => ({
-          ...status,
-          walletAddress,
-          provider,
-          meta,
-        }))
-      }),
+      this.transactions.map(
+        async ({ hash, provider, walletAddress, meta, status }) => {
+          // TODO: We dont need to check for ACCEPTED_ON_L1 currently, as we just handle ACCEPTED_ON_L2 anyways. This may changes in the future.
+          // if (status === "ACCEPTED_ON_L1" || status === "REJECTED") {
+          if (status === "ACCEPTED_ON_L2" || status === "REJECTED") {
+            return Promise.resolve({
+              hash,
+              provider,
+              walletAddress,
+              meta,
+              status,
+            })
+          }
+          return getTransactionStatus(provider, hash).then((status) => ({
+            ...status,
+            walletAddress,
+            provider,
+            meta,
+          }))
+        },
+      ),
     )
     if (transactionStatuses.length > 0) {
       // add transactions that were added while we were fetching


### PR DESCRIPTION
by stopping the pinging after finallity is reached
We're using `ACCEPTED_ON_L2` or `REJECTED` as final for now, this may need to change to `ACCEPTED_ON_L1` in the future