### PR TITLE
feat: open recover screen in a tab on linux

### DIFF
--- a/packages/extension/src/ui/hooks/useCustomNavigate.ts
+++ b/packages/extension/src/ui/hooks/useCustomNavigate.ts
@@ -1,0 +1,30 @@
+import { NavigateOptions, To, useNavigate } from "react-router-dom"
+import browser from "webextension-polyfill"
+
+const openExtensionInTab = () => {
+  const url = browser.runtime.getURL(`index.html`)
+  return browser.tabs.create({ url })
+}
+
+const isAlreadyInTab = async () => {
+  return Boolean(await browser.tabs.getCurrent())
+}
+
+const getPlatformOS = async () => {
+  const info = await browser.runtime.getPlatformInfo()
+  return info.os
+}
+
+export const useCustomNavigate = () => {
+  const navigate = useNavigate()
+
+  return async (to: To, options?: NavigateOptions) => {
+    const isLinux = (await getPlatformOS()) === "linux"
+    const isInTab = await isAlreadyInTab()
+
+    if (to === "/recover" && isLinux && !isInTab) {
+      return openExtensionInTab()
+    }
+    return navigate(to, options)
+  }
+}

--- a/packages/extension/src/ui/hooks/useCustomNavigate.ts
+++ b/packages/extension/src/ui/hooks/useCustomNavigate.ts
@@ -2,7 +2,7 @@ import { NavigateOptions, To, useNavigate } from "react-router-dom"
 import browser from "webextension-polyfill"
 
 const openExtensionInTab = () => {
-  const url = browser.runtime.getURL(`index.html`)
+  const url = browser.runtime.getURL("index.html")
   return browser.tabs.create({ url })
 }
 

--- a/packages/extension/src/ui/screens/WelcomeScreen.tsx
+++ b/packages/extension/src/ui/screens/WelcomeScreen.tsx
@@ -8,6 +8,7 @@ import { Greetings, GreetingsWrapper } from "../components/Greetings"
 import { StickyArgentFooter } from "../components/StickyArgentFooter"
 import { P } from "../components/Typography"
 import { routes } from "../routes"
+import { useCustomNavigate } from "../hooks/useCustomNavigate"
 
 const WelcomeScreenWrapper = styled.div`
   padding: 70px 40px 24px;
@@ -43,6 +44,7 @@ const greetings = [
 
 export const WelcomeScreen: FC = () => {
   const navigate = useNavigate()
+  const customNavigate = useCustomNavigate()
 
   return (
     <WelcomeScreenWrapper>
@@ -51,7 +53,7 @@ export const WelcomeScreen: FC = () => {
       <P>Enjoy the security of Ethereum with the scale of StarkNet</P>
       <ButtonGroup>
         <Button onClick={() => navigate(routes.newWallet())}>New wallet</Button>
-        <Button onClick={() => navigate(routes.recoverBackup())}>
+        <Button onClick={async () => await customNavigate(routes.recoverBackup())}>
           Restore wallet
         </Button>
       </ButtonGroup>


### PR DESCRIPTION
This is fixing issue #94 
On linux, when pressing "Recover Wallet" it will open the extension in a new browser tab.

It's not opening the recover screen but the welcome screen as in order to open that app at a given screen we need to change the main router

