### PR TITLE
fix(ci): review deps prs automatically

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           github-token: ${{ secrets.PAT }}
           script: |-
+            github.pulls.createReview({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.pull_request.number,
+              event: 'APPROVE'
+            })
             github.pulls.merge({
               owner: context.payload.repository.owner.login,
               repo: context.payload.repository.name,


### PR DESCRIPTION
it seems like you introduced some more restrictive github configs to the repo, therefore this change is needed