### PR TITLE
Feature/unauthorize dapp

### DIFF
--- a/packages/dapp/src/pages/index.tsx
+++ b/packages/dapp/src/pages/index.tsx
@@ -20,7 +20,12 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     addWalletChangeListener((accounts) => {
-      setAddress(accounts[0])
+      if (accounts.length > 0) {
+        setAddress(accounts[0])
+      } else {
+        setAddress("")
+        setIsConnected(false)
+      }
     })
   }, [])
 

--- a/packages/extension/src/background/activeTabs.ts
+++ b/packages/extension/src/background/activeTabs.ts
@@ -3,11 +3,21 @@ import browser from "webextension-polyfill"
 import { sendMessage } from "../shared/messages"
 import { MessageType } from "../shared/MessageType"
 
-const activeTabs = new Set<number>()
+type Tab = { id: number; host: string }
+const activeTabs: Tab[] = []
 
-export function addTab(tabId?: number) {
-  if (tabId !== undefined && !hasTab(tabId)) {
-    activeTabs.add(tabId)
+export function addTab(tab: Tab) {
+  if (tab.id !== undefined && !hasTab(tab.id)) {
+    activeTabs.push(tab)
+  }
+}
+
+export function removeTab(tabId?: number) {
+  if (tabId !== undefined && hasTab(tabId)) {
+    activeTabs.splice(
+      activeTabs.findIndex((tab) => tab.id === tabId),
+      1,
+    )
   }
 }
 
@@ -15,12 +25,32 @@ export function hasTab(tabId?: number) {
   if (tabId === undefined) {
     return false
   }
-  return activeTabs.has(tabId)
+  return activeTabs.some((tab) => tab.id === tabId)
 }
 
 browser.tabs.onRemoved.addListener((tabId) => {
-  activeTabs.delete(tabId)
+  removeTab(tabId)
 })
+
+export function getTabIdsOfHost(host: string) {
+  return activeTabs.filter((tab) => tab.host === host).map((tab) => tab.id)
+}
+
+export function removeTabOfHost(host: string) {
+  getTabIdsOfHost(host).forEach((tabId) => {
+    removeTab(tabId)
+  })
+}
+
+export async function sendMessageToHost(
+  message: MessageType,
+  host: string,
+): Promise<void> {
+  const tabIds = getTabIdsOfHost(host)
+  await Promise.allSettled(
+    tabIds.map((tabId) => sendMessage(message, { tabId })),
+  )
+}
 
 export async function sendMessageToActiveTabs(
   message: MessageType,
@@ -28,7 +58,10 @@ export async function sendMessageToActiveTabs(
 ): Promise<void> {
   const promises = []
   // Set avoids duplicates
-  for (const tabId of new Set([...activeTabs, ...additionalTargets])) {
+  for (const tabId of new Set([
+    ...activeTabs.map((tab) => tab.id),
+    ...additionalTargets,
+  ])) {
     if (tabId !== undefined) {
       promises.push(sendMessage(message, { tabId }))
     }

--- a/packages/extension/src/background/activeTabs.ts
+++ b/packages/extension/src/background/activeTabs.ts
@@ -3,7 +3,10 @@ import browser from "webextension-polyfill"
 import { sendMessage } from "../shared/messages"
 import { MessageType } from "../shared/MessageType"
 
-type Tab = { id: number; host: string }
+interface Tab {
+  id: number
+  host: string
+}
 const activeTabs: Tab[] = []
 
 export function addTab(tab: Tab) {
@@ -28,7 +31,7 @@ export function hasTab(tabId?: number) {
   return activeTabs.some((tab) => tab.id === tabId)
 }
 
-browser.tabs.onRemoved.addListener((tabId) => {
+browser.tabs.onRemoved.addListener(removeTab)
   removeTab(tabId)
 })
 

--- a/packages/extension/src/background/activeTabs.ts
+++ b/packages/extension/src/background/activeTabs.ts
@@ -32,8 +32,6 @@ export function hasTab(tabId?: number) {
 }
 
 browser.tabs.onRemoved.addListener(removeTab)
-  removeTab(tabId)
-})
 
 export function getTabIdsOfHost(host: string) {
   return activeTabs.filter((tab) => tab.host === host).map((tab) => tab.id)

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -175,11 +175,6 @@ import { Wallet, WalletStorageProps } from "./wallet"
             type: "CONNECT_DAPP",
             payload: { host: msg.data.host },
           })
-          return openUi()
-        }
-
-        if (!wallet.isSessionOpen()) {
-          return openUi()
         }
 
         if (isAuthorized && selectedAccount?.address) {
@@ -189,7 +184,7 @@ import { Wallet, WalletStorageProps } from "./wallet"
           })
         }
 
-        break
+        return openUi()
       }
 
       case "CONNECT_ACCOUNT": {

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -87,6 +87,10 @@ import { Wallet, WalletStorageProps } from "./wallet"
       sendMessageToActiveTabs(msg)
     }
 
+    wallet.on("autoLock", async () => {
+      await sendToTabAndUi({ type: "DISCONNECT_ACCOUNT" })
+    })
+
     const actionQueue = await getQueue<ActionItem>({
       onUpdate: (actions) => {
         sendToTabAndUi({

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -30,8 +30,9 @@ import {
   isPreAuthorized,
   preAuthorize,
   removePreAuthorization,
+  resetPreAuthorizations,
 } from "./preAuthorizations"
-import { Storage, clearStorage, setToStorage } from "./storage"
+import { Storage, clearStorage } from "./storage"
 import { TransactionTracker, getTransactionStatus } from "./trackTransactions"
 import { Wallet, WalletStorageProps } from "./wallet"
 
@@ -384,9 +385,8 @@ import { Wallet, WalletStorageProps } from "./wallet"
         break
       }
       case "RESET_PREAUTHORIZATIONS": {
-        setToStorage(`PREAUTHORIZATION:APPROVED`, [])
-        setToStorage(`PREAUTHORIZATION:PENDING`, [])
-        return
+        await resetPreAuthorizations()
+        return sendToTabAndUi({ type: "DISCONNECT_ACCOUNT" })
       }
       case "GET_PUBLIC_KEY": {
         return sendToTabAndUi({

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -356,7 +356,8 @@ import { Wallet, WalletStorageProps } from "./wallet"
 
       case "RESET_ALL": {
         clearStorage()
-        return wallet.reset()
+        wallet.reset()
+        return sendToTabAndUi({ type: "DISCONNECT_ACCOUNT" })
       }
 
       case "PREAUTHORIZE": {

--- a/packages/extension/src/background/preAuthorizations.ts
+++ b/packages/extension/src/background/preAuthorizations.ts
@@ -22,3 +22,7 @@ export async function isPreAuthorized(host: string) {
   const approved = await getFromStorage<string[]>(`PREAUTHORIZATION:APPROVED`)
   return (approved || []).includes(host)
 }
+
+export async function resetPreAuthorizations() {
+  await setToStorage(`PREAUTHORIZATION:APPROVED`, [])
+}

--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "events"
+
 import { ethers } from "ethers"
 import { Account, ec, stark } from "starknet"
 
@@ -29,7 +31,7 @@ export interface WalletStorageProps {
   selected?: string
 }
 
-export class Wallet {
+export class Wallet extends EventEmitter {
   private accounts: WalletAccount[] = []
 
   private encryptedBackup?: string
@@ -39,6 +41,7 @@ export class Wallet {
   private compiledContract: string
 
   constructor(store: IStorage<WalletStorageProps>, compiledContract: string) {
+    super()
     this.store = store
     this.compiledContract = compiledContract
   }
@@ -258,6 +261,7 @@ export class Wallet {
 
     setTimeout(() => {
       this.lock()
+      this.emit("autoLock")
     }, SESSION_DURATION)
   }
 

--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -182,7 +182,7 @@ export class Wallet {
   }
 
   public async getSelectedAccount(): Promise<WalletAccount | undefined> {
-    if (this.accounts.length === 0) {
+    if (this.accounts.length === 0 || !this.isSessionOpen()) {
       return
     }
 

--- a/packages/extension/src/inpage/index.ts
+++ b/packages/extension/src/inpage/index.ts
@@ -166,6 +166,16 @@ window.addEventListener(
           handleEvent([address])
         }
       }
+    } else if (data.type === "DAPP_UNAUTHORIZED") {
+      if (!starknet) {
+        return
+      }
+      starknet.selectedAddress = undefined
+      starknet.account = undefined
+      starknet.isConnected = false
+      for (const handleEvent of userEventHandlers) {
+        handleEvent([])
+      }
     }
   },
 )

--- a/packages/extension/src/inpage/index.ts
+++ b/packages/extension/src/inpage/index.ts
@@ -111,7 +111,10 @@ const starknetWindowObject: StarknetWindowObject = {
           return
         }
 
-        if (data.type === "CONNECT_DAPP_RES" && data.data) {
+        if (
+          (data.type === "CONNECT_DAPP_RES" && data.data) ||
+          (data.type === "START_SESSION_RES" && data.data)
+        ) {
           window.removeEventListener("message", handleMessage)
           const { address, network } = data.data
           starknet.provider = getProvider(network)
@@ -166,7 +169,7 @@ window.addEventListener(
           handleEvent([address])
         }
       }
-    } else if (data.type === "DAPP_UNAUTHORIZED") {
+    } else if (data.type === "DISCONNECT_ACCOUNT") {
       if (!starknet) {
         return
       }

--- a/packages/extension/src/shared/MessageType.ts
+++ b/packages/extension/src/shared/MessageType.ts
@@ -65,9 +65,11 @@ export type MessageType =
       data: { host: string; actionHash: string }
     }
   | { type: "REMOVE_PREAUTHORIZATION"; data: string }
+  | { type: "REMOVE_PREAUTHORIZATION_RES" }
   | { type: "IS_PREAUTHORIZED"; data: string }
   | { type: "IS_PREAUTHORIZED_RES"; data: boolean }
   | { type: "RESET_PREAUTHORIZATIONS" }
+  | { type: "DAPP_UNAUTHORIZED" }
   // ***** sessions *****
   | { type: "STOP_SESSION" }
   | { type: "HAS_SESSION" }

--- a/packages/extension/src/shared/MessageType.ts
+++ b/packages/extension/src/shared/MessageType.ts
@@ -23,6 +23,7 @@ export type MessageType =
   | { type: "GET_ACCOUNTS" }
   | { type: "GET_ACCOUNTS_RES"; data: WalletAccount[] }
   | { type: "CONNECT_ACCOUNT"; data: WalletAccount }
+  | { type: "DISCONNECT_ACCOUNT" }
   | { type: "GET_SELECTED_ACCOUNT" }
   | { type: "GET_SELECTED_ACCOUNT_RES"; data: WalletAccount | undefined }
   | { type: "DELETE_ACCOUNT"; data: string }
@@ -69,7 +70,6 @@ export type MessageType =
   | { type: "IS_PREAUTHORIZED"; data: string }
   | { type: "IS_PREAUTHORIZED_RES"; data: boolean }
   | { type: "RESET_PREAUTHORIZATIONS" }
-  | { type: "DAPP_UNAUTHORIZED" }
   // ***** sessions *****
   | { type: "STOP_SESSION" }
   | { type: "HAS_SESSION" }
@@ -81,7 +81,7 @@ export type MessageType =
     }
   | { type: "START_SESSION"; data: { secure: true; body: string } }
   | { type: "START_SESSION_REJ" }
-  | { type: "START_SESSION_RES" }
+  | { type: "START_SESSION_RES"; data?: WalletAccount }
   // ***** backup *****
   | { type: "RECOVER_BACKUP"; data: string }
   | { type: "RECOVER_BACKUP_RES" }

--- a/packages/extension/src/ui/index.html
+++ b/packages/extension/src/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Extension</title>
+    <title>ArgentX</title>
     <base href="/" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/extension/src/ui/screens/SettingsDappConnectionsScreen.tsx
+++ b/packages/extension/src/ui/screens/SettingsDappConnectionsScreen.tsx
@@ -4,8 +4,8 @@ import styled from "styled-components"
 
 import {
   getPreAuthorizations,
-  removePreAuthorization,
 } from "../../background/preAuthorizations"
+import { removePreAuthorization } from "../utils/messaging"
 import { sendMessage } from "../../shared/messages"
 import { BackButton } from "../components/BackButton"
 import { Button } from "../components/Button"

--- a/packages/extension/src/ui/utils/messaging.ts
+++ b/packages/extension/src/ui/utils/messaging.ts
@@ -106,3 +106,11 @@ export const deleteAccount = async (address: string) => {
     throw Error("Could not delete account")
   }
 }
+
+export const removePreAuthorization = async (host: string) => {
+  sendMessage({
+    type: "REMOVE_PREAUTHORIZATION",
+    data: host,
+  })
+  await waitForMessage("REMOVE_PREAUTHORIZATION_RES")
+}


### PR DESCRIPTION
Those two actions: 

* un-authorizing a dapp in the settings, 
* locking the wallet,

will clear the account and address from the injected `starknet` object and the dapp can adapt accordingly (disconnect). The code is inspired from #348 and #351 from @jasonzhouu which were not merges as they are since `develop` branch had evolved a lot since then.

We **don't implement** a `disconnect()` method that would allow a dapp to remove it's own authorization because we believe that should happen in the extension.

This PR should solve these issues too:
* #292
* #295
* #358
