### PR TITLE
feat(ui): improve backup download flow

### DIFF
--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -82,12 +82,12 @@ const Screen: FC = () => {
 
   const { isLoading } = useAppState()
   const { actions } = useActions()
-  const { isBackupDownloadRequired, dontRemindUser } = useBackupDownload()
+  const { isBackupDownloadRequired } = useBackupDownload()
 
   if (isLoading) {
     return <LoadingScreen />
   }
-  if (isBackupDownloadRequired && !dontRemindUser) {
+  if (isBackupDownloadRequired) {
     return <BackupDownloadScreen />
   }
 

--- a/packages/extension/src/ui/screens/BackupDownloadScreen.tsx
+++ b/packages/extension/src/ui/screens/BackupDownloadScreen.tsx
@@ -1,4 +1,4 @@
-import { FC, FormEventHandler, useState } from "react"
+import { FC, FormEventHandler } from "react"
 import { useLocation, useNavigate } from "react-router-dom"
 import styled from "styled-components"
 
@@ -11,10 +11,6 @@ import { routes } from "../routes"
 import { useBackupDownload } from "../states/backupDownload"
 
 const DownloadButton = styled(Button)`
-  margin-top: 20px;
-`
-
-const ContinueButton = styled(Button)`
   margin-top: auto;
 `
 
@@ -25,41 +21,16 @@ const Container = styled.div`
   height: calc(100vh - 68px);
 `
 
-const Notice = styled.div`
-  padding-top: 20px;
-  display: flex;
-  margin: 0 auto;
-  font-size: 12px;
-  cursor: pointer;
-
-  &:hover {
-    text-decoration: underline;
-  }
-`
-
 export const BackupDownloadScreen: FC = () => {
   const navigate = useNavigate()
   const { search } = useLocation()
-  const [isDownloaded, setIsDownloaded] = useState(false)
 
   const isSettings = new URLSearchParams(search).has("settings")
 
   const handleDownloadClick: FormEventHandler = async () => {
     sendMessage({ type: "DOWNLOAD_BACKUP_FILE" })
-    setIsDownloaded(true)
-  }
-
-  const handleContinueClick: FormEventHandler = async () => {
     useBackupDownload.setState({ isBackupDownloadRequired: false })
-    navigate(routes.account())
-  }
-
-  const handleDontShowClick: FormEventHandler = async () => {
-    useBackupDownload.setState({
-      isBackupDownloadRequired: false,
-      dontRemindUser: true,
-    })
-    navigate(routes.account())
+    navigate(isSettings ? routes.settings() : routes.account())
   }
 
   return (
@@ -72,23 +43,13 @@ export const BackupDownloadScreen: FC = () => {
         <H2>Download your backup</H2>
         <P>
           This is encrypted by your password and required if you need to restore
-          your account.
+          your accounts.
         </P>
         <P style={{ marginTop: 10 }}>
           Each time you add a new account, you&apos;ll be prompted to download
           an updated backup file for all your accounts.
         </P>
         <DownloadButton onClick={handleDownloadClick}>Download</DownloadButton>
-        {isDownloaded && !isSettings && (
-          <>
-            <ContinueButton onClick={handleContinueClick}>
-              Continue
-            </ContinueButton>
-            <Notice onClick={handleDontShowClick}>
-              Don&apos;t show this message again
-            </Notice>
-          </>
-        )}
       </Container>
     </>
   )

--- a/packages/extension/src/ui/states/backupDownload.ts
+++ b/packages/extension/src/ui/states/backupDownload.ts
@@ -3,14 +3,12 @@ import { persist } from "zustand/middleware"
 
 export interface BackupState {
   isBackupDownloadRequired: boolean
-  dontRemindUser: boolean
 }
 
 export const useBackupDownload = create<BackupState>(
   persist(
     (_set, _get) => ({
       isBackupDownloadRequired: false,
-      dontRemindUser: false,
     }),
     { name: "backupDownload" },
   ),


### PR DESCRIPTION
- always show backup download screen whenever there's a change to the wallet (no more don't remind me again option)
- go directly to relevant screen after download
- typos