### PR TITLE
feat: new recovery

### DIFF
--- a/packages/extension/src/background/networkMessaging.ts
+++ b/packages/extension/src/background/networkMessaging.ts
@@ -24,7 +24,7 @@ export const handleNetworkMessage: HandleMessage<NetworkMessage> = async ({
       const newNetworks = await addNetworks(networks)
       await Promise.all(
         newNetworks.map(
-          (network) => wallet.discoverAccountsForNetwork(network.id, 2), // just close gaps up to 1 blank space, as these networks are new and should be linked lists
+          (network) => wallet.discoverAccountsForNetwork(network, 2), // just close gaps up to 1 blank space, as these networks are new and should be linked lists
         ),
       )
       return sendToTabAndUi({

--- a/packages/extension/src/background/recoveryMessaging.ts
+++ b/packages/extension/src/background/recoveryMessaging.ts
@@ -55,7 +55,8 @@ export const handleRecoveryMessage: HandleMessage<RecoveryMessage> = async ({
         transactionTracker.load(await wallet.getAccounts())
 
         return sendToTabAndUi({ type: "RECOVER_SEEDPHRASE_RES" })
-      } catch {
+      } catch (e) {
+        console.error(e)
         return sendToTabAndUi({ type: "RECOVER_SEEDPHRASE_REJ" })
       }
     }

--- a/packages/extension/src/background/recoveryMessaging.ts
+++ b/packages/extension/src/background/recoveryMessaging.ts
@@ -55,8 +55,8 @@ export const handleRecoveryMessage: HandleMessage<RecoveryMessage> = async ({
         transactionTracker.load(await wallet.getAccounts())
 
         return sendToTabAndUi({ type: "RECOVER_SEEDPHRASE_RES" })
-      } catch (e) {
-        console.error(e)
+      } catch (error) {
+        console.error(error)
         return sendToTabAndUi({ type: "RECOVER_SEEDPHRASE_REJ" })
       }
     }

--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -250,6 +250,7 @@ export class Wallet {
     network: Network,
     offset: number = CHECK_OFFSET,
   ): Promise<WalletAccount[]> {
+    // FIXME: delete this once Cairo 9 is on mainnet
     if (!network?.accountClassHash) {
       const accountImplementationAddresses = union(
         isKnownNetwork(network.id)
@@ -485,7 +486,7 @@ export class Wallet {
     // FIXME: delete this once Cairo 9 is on mainnet
     const network = await this.getNetwork(networkId)
     if (!network.accountClassHash) {
-      return await this.addAccountPreCairo9(networkId)
+      return await this.addAccountPre9(networkId)
     }
 
     const currentPaths = (await this.getAccounts())
@@ -540,7 +541,7 @@ export class Wallet {
   }
 
   // FIXME: delete this once Cairo 9 is on mainnet
-  public async addAccountPreCairo9(
+  public async addAccountPre9(
     networkId: string,
   ): Promise<{ account: WalletAccount; txHash: string }> {
     if (!this.isSessionOpen()) {

--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -365,14 +365,13 @@ export class Wallet {
   }
 
   public async discoverAccountsForNetwork(
-    networkId: string,
+    network?: Network,
     offset: number = CHECK_OFFSET,
   ) {
     if (!this.isSessionOpen() || !this.session?.secret) {
       throw new Error("Session is not open")
     }
     const wallet = new ethers.Wallet(this.session?.secret)
-    const network = await this.getNetwork(networkId)
 
     if (!network?.accountImplementation) {
       // silent fail if no account implementation is defined for this network
@@ -495,7 +494,7 @@ export class Wallet {
       implementation = deployImplementationTransaction.address as string
     } else {
       // if there is an implementation, we need to check if accounts were already deployed
-      this.discoverAccountsForNetwork(networkId)
+      this.discoverAccountsForNetwork(network)
     }
 
     const deployTransaction = await provider.deployContract({

--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -246,6 +246,16 @@ export class Wallet {
     proxyContactHashes: string[] = PROXY_CONTRACT_HASHES_TO_CHECK,
     offset: number = CHECK_OFFSET,
   ): Promise<WalletAccount[]> {
+    if (!network?.accountClassHash) {
+      return this.restoreAccountsFromWalletPre9(
+        secret,
+        network,
+        accountImplementationAddresses,
+        proxyContactHashes,
+        offset,
+      )
+    }
+
     return this.restoreAccountsFromWalletPre9(
       secret,
       network,
@@ -286,7 +296,7 @@ export class Wallet {
           const starkPair = getStarkPair(
             lastCheck,
             secret,
-            newBaseDerivationPath,
+            oldBaseDerivationPath,
           )
           const starkPub = ec.getStarkKey(starkPair)
           const seed = starkPub
@@ -308,7 +318,7 @@ export class Wallet {
                 type: "local_signer",
                 derivationPath: getPathForIndex(
                   lastCheck,
-                  newBaseDerivationPath,
+                  oldBaseDerivationPath,
                 ),
               },
             })

--- a/packages/extension/test/wallet.test.ts
+++ b/packages/extension/test/wallet.test.ts
@@ -90,6 +90,7 @@ test("open existing wallet", async () => {
 
   const storage = new MockStorage<WalletStorageProps>()
   storage.setItem("backup", backupString)
+  storage.setItem("discoveredOnce", true)
   const wallet = new Wallet(storage, loadContracts, getNetwork)
   await wallet.setup()
 
@@ -123,6 +124,7 @@ test("open existing wallet", async () => {
 test("open existing wallet with wrong password", async () => {
   const storage = new MockStorage<WalletStorageProps>()
   storage.setItem("backup", backupString)
+  storage.setItem("discoveredOnce", true)
   const wallet = new Wallet(storage, loadContracts, getNetwork)
   await wallet.setup()
 
@@ -137,6 +139,7 @@ test("import backup file", async () => {
   jest.useFakeTimers()
 
   const storage = new MockStorage<WalletStorageProps>()
+  storage.setItem("discoveredOnce", true)
   const wallet = new Wallet(storage, loadContracts, getNetwork)
   await wallet.setup()
 


### PR DESCRIPTION
if accountClassHash is provided for a network we use the new recovery mechanism. This allows only to recover new accounts and ignores any old accounts on that network.

If the network still has no accountClassHash we consider it pre cairo v0.9.0 and use the old recovery mechanism.

Pre cairo v0.9.0 should be removed as soon as devnet and mainnet support it.