### PR TITLE
fix: ensure normalized address in view on voyager link

### DIFF
--- a/packages/extension/src/ui/services/voyager.service.ts
+++ b/packages/extension/src/ui/services/voyager.service.ts
@@ -1,6 +1,7 @@
 import join from "url-join"
 
 import { Network } from "../../shared/networks"
+import { normalizeAddress } from "./addresses"
 
 export const getVoyagerContractLink = (
   address: string,
@@ -10,7 +11,7 @@ export const getVoyagerContractLink = (
   if (!explorerUrl) {
     return ""
   }
-  return join(explorerUrl, "contract", address)
+  return join(explorerUrl, "contract", normalizeAddress(address))
 }
 
 export const getVoyagerTransactionLink = (


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/11096006/172430060-45640447-e0ff-4bb9-b933-a97bec48ccf7.png)


- If the address has padded 0's, View On Voyager link is opening without initial 0's, which is fine for Voyager but it's creating inconsistency of address lengths and it can be confusing for customers. 
- For Copy to Clipboard it was already implemented (the value copied to the clipboard is padded with 0's)

