### PR TITLE
feat: high level app error capture

### DIFF
--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -63,6 +63,8 @@ const theme = createTheme({
   },
 })
 
+const isDev = process.env.NODE_ENV === "development"
+
 const Thrower: FC = () => {
   const [shouldThrow, setShouldThrow] = useState(false)
   const throwClicked = useCallback(() => {
@@ -91,7 +93,7 @@ export const App: FC = () => {
         <ErrorBoundary fallback={<AppErrorBoundaryFallback />}>
           <Suspense fallback={<LoadingScreen />}>
             <>
-              <Thrower />
+              {isDev && <Thrower />}
               <AppRoutes />
             </>
           </Suspense>

--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -1,10 +1,12 @@
 import { ThemeProvider, createTheme } from "@mui/material"
-import { FC, Suspense } from "react"
+import { FC, Suspense, useCallback, useEffect, useState } from "react"
 import { createGlobalStyle } from "styled-components"
 import { normalize } from "styled-normalize"
 import { SWRConfig } from "swr"
 
+import AppErrorBoundaryFallback from "./AppErrorBoundaryFallback"
 import { AppRoutes } from "./AppRoutes"
+import { ErrorBoundary } from "./components/ErrorBoundary"
 import { LoadingScreen } from "./features/actions/LoadingScreen"
 import { useExtensionIsInTab } from "./features/browser/tabs"
 import { swrCacheProvider } from "./services/swr"
@@ -61,6 +63,19 @@ const theme = createTheme({
   },
 })
 
+const Thrower: FC = () => {
+  const [shouldThrow, setShouldThrow] = useState(false)
+  const throwClicked = useCallback(() => {
+    setShouldThrow((shouldThrow) => !shouldThrow)
+  }, [])
+  useEffect(() => {
+    if (shouldThrow) {
+      throw "Threw a manual exception"
+    }
+  }, [shouldThrow])
+  return <button onClick={throwClicked}>Throw</button>
+}
+
 export const App: FC = () => {
   const extensionIsInTab = useExtensionIsInTab()
   return (
@@ -73,9 +88,14 @@ export const App: FC = () => {
           rel="stylesheet"
         />
         <GlobalStyle extensionIsInTab={extensionIsInTab} />
-        <Suspense fallback={<LoadingScreen />}>
-          <AppRoutes />
-        </Suspense>
+        <ErrorBoundary fallback={<AppErrorBoundaryFallback />}>
+          <Suspense fallback={<LoadingScreen />}>
+            <>
+              <Thrower />
+              <AppRoutes />
+            </>
+          </Suspense>
+        </ErrorBoundary>
       </ThemeProvider>
     </SWRConfig>
   )

--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -66,14 +66,14 @@ export const App: FC = () => {
   return (
     <SWRConfig value={{ provider: () => swrCacheProvider }}>
       <ThemeProvider theme={theme}>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700;900&display=swap"
+          rel="stylesheet"
+        />
+        <GlobalStyle extensionIsInTab={extensionIsInTab} />
         <Suspense fallback={<LoadingScreen />}>
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700;900&display=swap"
-            rel="stylesheet"
-          />
-          <GlobalStyle extensionIsInTab={extensionIsInTab} />
           <AppRoutes />
         </Suspense>
       </ThemeProvider>

--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -1,5 +1,5 @@
 import { ThemeProvider, createTheme } from "@mui/material"
-import { FC, Suspense, useCallback, useEffect, useState } from "react"
+import { FC, Suspense } from "react"
 import { createGlobalStyle } from "styled-components"
 import { normalize } from "styled-normalize"
 import { SWRConfig } from "swr"
@@ -63,21 +63,6 @@ const theme = createTheme({
   },
 })
 
-const isDev = process.env.NODE_ENV === "development"
-
-const Thrower: FC = () => {
-  const [shouldThrow, setShouldThrow] = useState(false)
-  const throwClicked = useCallback(() => {
-    setShouldThrow((shouldThrow) => !shouldThrow)
-  }, [])
-  useEffect(() => {
-    if (shouldThrow) {
-      throw "Threw a manual exception"
-    }
-  }, [shouldThrow])
-  return <button onClick={throwClicked}>Throw</button>
-}
-
 export const App: FC = () => {
   const extensionIsInTab = useExtensionIsInTab()
   return (
@@ -92,10 +77,7 @@ export const App: FC = () => {
         <GlobalStyle extensionIsInTab={extensionIsInTab} />
         <ErrorBoundary fallback={<AppErrorBoundaryFallback />}>
           <Suspense fallback={<LoadingScreen />}>
-            <>
-              {isDev && <Thrower />}
-              <AppRoutes />
-            </>
+            <AppRoutes />
           </Suspense>
         </ErrorBoundary>
       </ThemeProvider>

--- a/packages/extension/src/ui/AppErrorBoundaryFallback.tsx
+++ b/packages/extension/src/ui/AppErrorBoundaryFallback.tsx
@@ -1,0 +1,77 @@
+import { FC, useCallback } from "react"
+import styled from "styled-components"
+import browser from "webextension-polyfill"
+
+import { Button } from "./components/Button"
+import { CopyTooltip } from "./components/CopyTooltip"
+import { ErrorBoundaryState } from "./components/ErrorBoundary"
+import {
+  ContentCopyIcon,
+  ReportGmailerrorredIcon,
+} from "./components/Icons/MuiIcons"
+import { P } from "./components/Typography"
+import { SupportFooter } from "./features/settings/SettingsScreen"
+
+const FullscreenFallbackContainer = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+`
+const MessageContainer = styled.div`
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`
+const ButtonContainer = styled.div`
+  display: flex;
+  padding: 24px 32px;
+`
+const ErrorIcon = styled(ReportGmailerrorredIcon)`
+  color: red;
+  font-size: 64px;
+  margin-bottom: 16px;
+`
+
+const StyledContentCopyIcon = styled(ContentCopyIcon)`
+  margin-left: 0.5em;
+  cursor: pointer;
+  font-size: 12px;
+`
+
+const AppErrorBoundaryFallback: FC<ErrorBoundaryState> = ({
+  error,
+  errorInfo,
+}) => {
+  const onReload = useCallback(() => {
+    const url = browser.runtime.getURL("index.html")
+    window.location.href = url
+  }, [])
+
+  const displayError =
+    error && error.toString ? error.toString() : "Unknown error"
+  const displayStack = errorInfo ? errorInfo.componentStack : "No stack trace"
+
+  return (
+    <FullscreenFallbackContainer>
+      <MessageContainer>
+        <ErrorIcon />
+        <P>Sorry, an error ocurred</P>
+        <CopyTooltip message="Copied" copyValue={"Hello!"}>
+          <StyledContentCopyIcon />
+        </CopyTooltip>
+        <pre>{JSON.stringify({ displayError, displayStack }, null, 2)}</pre>
+      </MessageContainer>
+      <SupportFooter />
+      <ButtonContainer>
+        <Button type="submit" onClick={onReload}>
+          Reload
+        </Button>
+      </ButtonContainer>
+    </FullscreenFallbackContainer>
+  )
+}
+
+export default AppErrorBoundaryFallback

--- a/packages/extension/src/ui/AppErrorBoundaryFallback.tsx
+++ b/packages/extension/src/ui/AppErrorBoundaryFallback.tsx
@@ -60,10 +60,10 @@ const StyledContentCopyIcon = styled(ContentCopyIcon)`
 `
 
 const version = process.env.VERSION
-const fallbackErrorPayload = JSON.stringify({
-  version,
-  error: "Unable to parse error",
-})
+const fallbackErrorPayload = `v${version}
+
+Unable to parse error
+`
 
 const AppErrorBoundaryFallback: FC<ErrorBoundaryState> = ({
   error,
@@ -82,12 +82,11 @@ const AppErrorBoundaryFallback: FC<ErrorBoundaryState> = ({
         errorInfo && errorInfo?.componentStack
           ? errorInfo.componentStack
           : "No stack trace"
-      const payload = {
-        version,
-        error: displayError,
-        stackTrace: displayStack,
-      }
-      return JSON.stringify(payload, null, 2)
+      return `v${version}
+
+${displayError}
+${displayStack}
+      `
     } catch (e) {
       // ignore error
     }

--- a/packages/extension/src/ui/AppErrorBoundaryFallback.tsx
+++ b/packages/extension/src/ui/AppErrorBoundaryFallback.tsx
@@ -99,7 +99,7 @@ const AppErrorBoundaryFallback: FC<ErrorBoundaryState> = ({
       <MessageContainer>
         <ErrorIcon />
         <ErrorMessageContainer>
-          <P>Sorry, an error ocurred</P>
+          <P>Sorry, an error occurred</P>
         </ErrorMessageContainer>
         <CopyTooltip message="Copied" copyValue={errorPayload}>
           <CopyDetailsContainer>

--- a/packages/extension/src/ui/AppErrorBoundaryFallback.tsx
+++ b/packages/extension/src/ui/AppErrorBoundaryFallback.tsx
@@ -76,12 +76,8 @@ const AppErrorBoundaryFallback: FC<ErrorBoundaryState> = ({
 
   const errorPayload = useMemo(() => {
     try {
-      const displayError =
-        error && error.toString ? error.toString() : "Unknown error"
-      const displayStack =
-        errorInfo && errorInfo?.componentStack
-          ? errorInfo.componentStack
-          : "No stack trace"
+      const displayError = error?.toString?.() || "Unknown error"
+      const displayStack = errorInfo.componentStack || "No stack trace"
       return `v${version}
 
 ${displayError}

--- a/packages/extension/src/ui/components/ErrorBoundary.tsx
+++ b/packages/extension/src/ui/components/ErrorBoundary.tsx
@@ -1,25 +1,41 @@
-import { Component } from "react"
+import { Component, cloneElement } from "react"
 
 interface ErrorBoundaryProps {
-  fallback: React.ReactNode
+  fallback: React.ReactElement
   children: React.ReactNode
 }
 
-interface ErrorBoundaryState {
-  hasError: boolean
+export interface ErrorBoundaryState {
+  error?: any
+  errorInfo?: any
 }
 
 export class ErrorBoundary extends Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
 > {
-  state = { hasError: false }
+  state = { error: null, errorInfo: null }
 
-  static getDerivedStateFromError(_error: unknown) {
-    return { hasError: true }
+  /** server-side error */
+  static getDerivedStateFromError(error: unknown) {
+    return {
+      error,
+    }
+  }
+
+  /** client-side error with info */
+  componentDidCatch(error: any, errorInfo: any) {
+    this.setState({
+      error: error,
+      errorInfo: errorInfo,
+    })
   }
 
   render() {
-    return this.state.hasError ? this.props.fallback : this.props.children
+    if (this.state.error) {
+      const { error, errorInfo } = this.state
+      return cloneElement(this.props.fallback, { error, errorInfo })
+    }
+    return <>{this.props.children}</>
   }
 }

--- a/packages/extension/src/ui/features/accountTokens/AccountTokens.tsx
+++ b/packages/extension/src/ui/features/accountTokens/AccountTokens.tsx
@@ -115,17 +115,19 @@ export const AccountTokens: FC<AccountTokensProps> = ({ account }) => {
       {showNoBalanceForUpgrade && <UpgradeBanner canNotPay />}
       <PendingTransactions account={account} />
       <Suspense fallback={<Spinner size={64} style={{ marginTop: 40 }} />}>
-        <TokenList
-          showTitle={showPendingTransactions}
-          accountAddress={account.address}
-          canShowEmptyAccountAlert={canShowEmptyAccountAlert}
-        />
-        <TokenWrapper {...makeClickable(() => navigate(routes.newToken()))}>
-          <AddTokenIconButton size={40}>
-            <AddIcon />
-          </AddTokenIconButton>
-          <TokenTitle>Add token</TokenTitle>
-        </TokenWrapper>
+        <>
+          <TokenList
+            showTitle={showPendingTransactions}
+            accountAddress={account.address}
+            canShowEmptyAccountAlert={canShowEmptyAccountAlert}
+          />
+          <TokenWrapper {...makeClickable(() => navigate(routes.newToken()))}>
+            <AddTokenIconButton size={40}>
+              <AddIcon />
+            </AddTokenIconButton>
+            <TokenTitle>Add token</TokenTitle>
+          </TokenWrapper>
+        </>
       </Suspense>
     </Container>
   )

--- a/packages/extension/src/ui/features/settings/SettingsScreen.tsx
+++ b/packages/extension/src/ui/features/settings/SettingsScreen.tsx
@@ -71,6 +71,36 @@ const Footer = styled.div`
   }
 `
 
+export const SupportFooter: FC = () => (
+  <Footer>
+    <P>Help, support &amp; suggestions:</P>
+    <div>
+      <a
+        href="https://discord.com/channels/793094838509764618/908663762150645770"
+        title="Ask a question on the argent-extension channel on StarkNet Discord"
+        target="_blank"
+      >
+        <img
+          src="https://images.prismic.io/argentwebsite/76eac5a3-a4a3-4395-a82a-a3def2438ff0_icon-discord.svg?auto=format%2Ccompress&amp;fit=max&amp;q=50"
+          alt="Argent Discord icon"
+        />
+      </a>
+      <a
+        href="https://github.com/argentlabs/argent-x/issues"
+        title="Post an issue on Argent X GitHub"
+        target="_blank"
+        style={{ marginLeft: 15 }}
+      >
+        <img
+          src="https://images.prismic.io/argentwebsite/460e2528-d9bb-4a47-9339-b72c287c243e_icon-github.svg?auto=format%2Ccompress&amp;fit=max&amp;q=50"
+          alt="Argent Github icon"
+        />
+      </a>
+    </div>
+    <P>Version: v{process.env.VERSION}</P>
+  </Footer>
+)
+
 export const SettingsScreen: FC = () => {
   const openExtensionInTab = useOpenExtensionInTab()
   const extensionIsInTab = useExtensionIsInTab()
@@ -128,33 +158,7 @@ export const SettingsScreen: FC = () => {
         </SettingsItem>
         <hr />
 
-        <Footer>
-          <P>Help, support &amp; suggestions:</P>
-          <div>
-            <a
-              href="https://discord.com/channels/793094838509764618/908663762150645770"
-              title="Ask a question on the argent-extension channel on StarkNet Discord"
-              target="_blank"
-            >
-              <img
-                src="https://images.prismic.io/argentwebsite/76eac5a3-a4a3-4395-a82a-a3def2438ff0_icon-discord.svg?auto=format%2Ccompress&amp;fit=max&amp;q=50"
-                alt="Argent Discord icon"
-              />
-            </a>
-            <a
-              href="https://github.com/argentlabs/argent-x/issues"
-              title="Post an issue on Argent X GitHub"
-              target="_blank"
-              style={{ marginLeft: 15 }}
-            >
-              <img
-                src="https://images.prismic.io/argentwebsite/460e2528-d9bb-4a47-9339-b72c287c243e_icon-github.svg?auto=format%2Ccompress&amp;fit=max&amp;q=50"
-                alt="Argent Github icon"
-              />
-            </a>
-          </div>
-          <P>Version: v{process.env.VERSION}</P>
-        </Footer>
+        <SupportFooter />
       </SettingsScreenWrapper>
     </>
   )


### PR DESCRIPTION
Provides improved structuring for React Suspense and a high-level error boundary which provides a way for users to copy an error payload.

https://user-images.githubusercontent.com/175607/174849338-70fd5406-e7eb-48ea-9a86-e2f34b27487d.mov

Example payload

```
v4.1.4

Threw a manual exception

    at Thrower (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:199894:42)
    at Suspense
    at ErrorBoundary (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:200470:47)
    at InnerThemeProvider (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:89592:70)
    at ThemeProvider (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:89120:5)
    at ThemeProvider (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:89612:5)
    at SWRConfig$1 (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:195343:23)
    at App (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:199906:59)
    at Router (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:181817:15)
    at BrowserRouter (chrome-extension://ibeadmeiklhobeoiaolmnhmegnmhlggg/main.js:180657:5)
```