### PR TITLE
fix: enable currency display only when on mainnet

### DIFF
--- a/packages/extension/src/ui/features/accountTokens/AccountTokens.tsx
+++ b/packages/extension/src/ui/features/accountTokens/AccountTokens.tsx
@@ -1,4 +1,4 @@
-import { FC, Suspense, useEffect, useMemo, useRef } from "react"
+import { FC, Suspense, useEffect, useRef } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import styled from "styled-components"
 import useSWR from "swr"
@@ -16,7 +16,6 @@ import { Spinner } from "../../components/Spinner"
 import { routes } from "../../routes"
 import { makeClickable } from "../../services/a11y"
 import { connectAccount } from "../../services/backgroundAccounts"
-import { useBackgroundSettingsValue } from "../../services/useBackgroundSettingsValue"
 import { PendingTransactions } from "../accountActivity/PendingTransactions"
 import { Account } from "../accounts/Account"
 import {
@@ -32,6 +31,7 @@ import { AccountSubHeader } from "./AccountSubheader"
 import { MigrationBanner } from "./MigrationBanner"
 import { TokenList } from "./TokenList"
 import { TokenTitle, TokenWrapper } from "./TokenListItem"
+import { useCurrencyDisplayEnabled } from "./tokenPriceHooks"
 import { fetchFeeTokenBalance } from "./tokens.service"
 import { TransferButtons } from "./TransferButtons"
 import { UpgradeBanner } from "./UpgradeBanner"
@@ -62,6 +62,7 @@ export const AccountTokens: FC<AccountTokensProps> = ({ account }) => {
   const { pendingTransactions } = useAccountTransactions(account)
   const { accountNames, setAccountName } = useAccountMetadata()
   const { isBackupRequired } = useBackupRequired()
+  const currencyDisplayEnabled = useCurrencyDisplayEnabled()
 
   const showPendingTransactions = pendingTransactions.length > 0
   const accountName = getAccountName(account, accountNames)
@@ -105,13 +106,7 @@ export const AccountTokens: FC<AccountTokensProps> = ({ account }) => {
     connectAccount(account)
   }, [account])
 
-  const { value: privacyUseArgentServicesEnabled } = useBackgroundSettingsValue(
-    "privacyUseArgentServices",
-  )
-  const tokenListVariant = useMemo(
-    () => (privacyUseArgentServicesEnabled ? "default" : "no-currency"),
-    [privacyUseArgentServicesEnabled],
-  )
+  const tokenListVariant = currencyDisplayEnabled ? "default" : "no-currency"
 
   return (
     <Container>

--- a/packages/extension/src/ui/features/accountTokens/tokenPriceHooks.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokenPriceHooks.ts
@@ -15,16 +15,25 @@ import {
 import { fetcher } from "../../../shared/utils/fetcher"
 import { useConditionallyEnabledSWR } from "../../services/swr"
 import { useBackgroundSettingsValue } from "../../services/useBackgroundSettingsValue"
+import { useIsMainnet } from "../networks/useNetworks"
 import { TokenDetails, TokenDetailsWithBalance } from "./tokens.state"
+
+/** @returns true if app is on mainnet and the user has enabled Argent services */
+
+export const useCurrencyDisplayEnabled = () => {
+  const isMainnet = useIsMainnet()
+  const { value: privacyUseArgentServicesEnabled } = useBackgroundSettingsValue(
+    "privacyUseArgentServices",
+  )
+  return isMainnet && privacyUseArgentServicesEnabled
+}
 
 /** @returns price and token data which will be cached and refreshed periodically by SWR */
 
 export const usePriceAndTokenDataFromApi = () => {
-  const { value: privacyUseArgentServicesEnabled } = useBackgroundSettingsValue(
-    "privacyUseArgentServices",
-  )
+  const currencyDisplayEnabled = useCurrencyDisplayEnabled()
   const { data: pricesData } = useConditionallyEnabledSWR<ApiPriceDataResponse>(
-    privacyUseArgentServicesEnabled,
+    currencyDisplayEnabled,
     `${ARGENT_API_TOKENS_PRICES_URL}`,
     fetcher,
     {
@@ -32,7 +41,7 @@ export const usePriceAndTokenDataFromApi = () => {
     },
   )
   const { data: tokenData } = useConditionallyEnabledSWR<ApiTokenDataResponse>(
-    privacyUseArgentServicesEnabled,
+    currencyDisplayEnabled,
     `${ARGENT_API_TOKENS_INFO_URL}`,
     fetcher,
     {

--- a/packages/extension/src/ui/features/networks/useNetworks.ts
+++ b/packages/extension/src/ui/features/networks/useNetworks.ts
@@ -52,3 +52,9 @@ export const useCurrentNetwork = () => {
 
   return currentNetwork.network
 }
+
+export const useIsMainnet = () => {
+  const { switcherNetworkId } = useAppState()
+  const isMainnet = switcherNetworkId === "mainnet-alpha"
+  return isMainnet
+}


### PR DESCRIPTION
Adds a `useIsMainnet` hook and uses it to check if the user is both on mainnet, and has Argent services enabled, before fetching and displaying token / pricing data

Video shows a user initially on Testnet with only token values displayed, switches to Mainnet showing both token and currency values ($0.00...!), then disabling Argent services which causes only token values. to be shown on Mainnet.

https://user-images.githubusercontent.com/175607/176479547-3a587863-24b1-416e-af45-2501cfb73150.mov


