### PR TITLE
fix: update reset screen text

### DIFF
--- a/packages/extension/src/ui/features/onboarding/ResetScreen.tsx
+++ b/packages/extension/src/ui/features/onboarding/ResetScreen.tsx
@@ -24,12 +24,9 @@ export const ResetScreen: FC = () => {
       }}
     >
       <P>
-        If you forgot your password, your only option for recovery is to reset
-        the extension and load your previously downloaded backup.
-      </P>
-      <P style={{ marginTop: 32 }}>
-        The backup downloads automatically each time you add an account to your
-        wallet.
+        If you reset your wallet, the only way to recover it is with your
+        12-word seed phrase. Make sure to back it up from the Argent X settings
+        and save it somewhere securely before resetting the extension
       </P>
     </ConfirmScreen>
   )


### PR DESCRIPTION
The current text in the reset screen is outdated. It mentions backup files and we’re not using them anymore.

![image](https://user-images.githubusercontent.com/50968441/177116422-b533d587-6f66-4a88-bae3-22b32c56fad1.png)

The new text should be:

“If you reset your wallet, the only way to recover it is with your 12-word seed phrase. Make sure to back it up from the Argent X settings and save it somewhere securely before resetting the extension“