### PR TITLE
fix: close popup after dapp extension unlock

### DIFF
--- a/packages/extension/playwright.config.ts
+++ b/packages/extension/playwright.config.ts
@@ -4,6 +4,10 @@ import { devices } from "@playwright/test"
 
 const config: PlaywrightTestConfig = {
   timeout: 5 * 60e3, // 5 minutes
+  reportSlowTests: {
+    threshold: 1 * 60e3, // 1 minutes
+    max: 5,
+  },
   forbidOnly: !!process.env.CI,
   testDir: "./e2e",
   retries: process.env.CI ? 2 : 0,

--- a/packages/extension/src/ui/features/onboarding/LockScreen.tsx
+++ b/packages/extension/src/ui/features/onboarding/LockScreen.tsx
@@ -8,6 +8,7 @@ import { P, StyledLink } from "../../components/Typography"
 import { routes } from "../../routes"
 import { unlockedExtensionTodayTracking } from "../../services/analytics"
 import { startSession } from "../../services/backgroundSessions"
+import { useActions } from "../actions/actions.state"
 import { StickyGroup } from "../actions/ConfirmScreen"
 import { recover } from "../recovery/recovery.service"
 import { Greetings, GreetingsWrapper } from "./Greetings"
@@ -44,6 +45,8 @@ export const greetings = [
   "hi fren",
 ]
 
+const isPopup = new URLSearchParams(window.location.search).has("popup")
+
 export const LockScreen: FC = () => {
   const navigate = useNavigate()
 
@@ -60,6 +63,12 @@ export const LockScreen: FC = () => {
             await startSession(password)
             unlockedExtensionTodayTracking()
             const target = await recover()
+
+            // If only called by dapp (in popup) because the wallet was locked, but the dapp is already whitelisted/no transactions requested (actions=0), then close
+            if (isPopup && !useActions.getState().actions.length) {
+              window.close()
+            }
+
             useAppState.setState({ isLoading: false })
             navigate(target)
             return true


### PR DESCRIPTION
when there are no other actions that need approval