### PR TITLE
fix: use consistent storage key for account deploy transaction

### DIFF
--- a/packages/extension/src/ui/features/accounts/Account.ts
+++ b/packages/extension/src/ui/features/accounts/Account.ts
@@ -41,7 +41,7 @@ export class Account {
       this.provider,
     )
 
-    const key = `deployTransaction:${getAccountIdentifier(this)}`
+    const key = this.getDeployTransactionStorageKey()
     if (deployTransaction) {
       localStorage.setItem(key, deployTransaction)
     } else if (localStorage.getItem(key)) {
@@ -49,8 +49,14 @@ export class Account {
     }
   }
 
+  public getDeployTransactionStorageKey(): string {
+    const key = `deployTransaction:${getAccountIdentifier(this)}`
+    return key
+  }
+
   public completeDeployTx(): void {
-    localStorage.removeItem(`deployTransaction:${this.address}`)
+    const key = this.getDeployTransactionStorageKey()
+    localStorage.removeItem(key)
     this.deployTransaction = undefined
   }
 


### PR DESCRIPTION
Fixes an issue where all accounts showed a status of 'deploying' for a split second as the deploy transaction was never removed on success.

Users will initially see the 'deploying' on first use, then the deploy transaction will be removed and 'deploying' will no longer show on subsequent launches.

Screen recording shows deploying accounts successfully, then repeatedly opening the extension and viewing the account list - 'deploying' no longer shown.

https://user-images.githubusercontent.com/175607/177519814-f9e6b1c8-9dd6-4727-a678-b9b68ba7ab9f.mov

