### PR TITLE
feat: add headers to argent api requests

### DIFF
--- a/packages/extension/src/shared/api/constants.ts
+++ b/packages/extension/src/shared/api/constants.ts
@@ -1,0 +1,30 @@
+import { isString } from "lodash-es"
+import urlJoin from "url-join"
+
+export const ARGENT_API_BASE_URL = process.env.ARGENT_API_BASE_URL as string
+
+export const ARGENT_API_ENABLED =
+  isString(ARGENT_API_BASE_URL) && ARGENT_API_BASE_URL.length > 0
+
+export const ARGENT_API_TOKENS_PRICES_URL = ARGENT_API_ENABLED
+  ? urlJoin(ARGENT_API_BASE_URL, "tokens/prices?chain=starknet")
+  : undefined
+
+export const ARGENT_API_TOKENS_INFO_URL = ARGENT_API_ENABLED
+  ? urlJoin(ARGENT_API_BASE_URL, "tokens/info?chain=starknet")
+  : undefined
+
+export const ARGENT_TRANSACTION_REVIEW_API_BASE_URL = process.env
+  .ARGENT_TRANSACTION_REVIEW_API_BASE_URL as string
+
+export const ARGENT_TRANSACTION_REVIEW_API_ENABLED =
+  isString(ARGENT_TRANSACTION_REVIEW_API_BASE_URL) &&
+  ARGENT_TRANSACTION_REVIEW_API_BASE_URL.length > 0
+
+export const ARGENT_TRANSACTION_REVIEW_STARKNET_URL =
+  ARGENT_TRANSACTION_REVIEW_API_ENABLED
+    ? urlJoin(
+        ARGENT_TRANSACTION_REVIEW_API_BASE_URL,
+        "transactions/review/starknet",
+      )
+    : undefined

--- a/packages/extension/src/shared/api/fetcher.ts
+++ b/packages/extension/src/shared/api/fetcher.ts
@@ -1,0 +1,48 @@
+/** generic json fetcher */
+
+import { KnownNetworksType } from "../networks"
+
+export type Fetcher = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<any>
+
+export const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const response = await fetch(input, init)
+  const json = await response.json()
+  return json
+}
+
+export const fetcherWithArgentApiHeadersForNetwork = (
+  network: KnownNetworksType,
+  fetcherImpl: Fetcher = fetcher,
+) => {
+  const fetcherWithArgentApiHeaders = (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    const initWithArgentApiHeaders = {
+      ...init,
+      headers: {
+        ...init?.headers,
+        ...argentApiHeadersForNetwork(network),
+      },
+    }
+    return fetcherImpl(input, initWithArgentApiHeaders)
+  }
+  return fetcherWithArgentApiHeaders
+}
+
+/** convert KnownNetworksType to 'goerli' or 'mainnet' expected by API */
+
+export const argentApiNetworkForNetwork = (network: KnownNetworksType) => {
+  return network === "goerli-alpha" ? "goerli" : "mainnet"
+}
+
+export const argentApiHeadersForNetwork = (network: KnownNetworksType) => {
+  return {
+    "argent-version": process.env.VERSION || "",
+    "argent-client": "argent-x",
+    "argent-network": argentApiNetworkForNetwork(network),
+  }
+}

--- a/packages/extension/src/shared/api/fetcher.ts
+++ b/packages/extension/src/shared/api/fetcher.ts
@@ -41,7 +41,7 @@ export const argentApiNetworkForNetwork = (network: KnownNetworksType) => {
 
 export const argentApiHeadersForNetwork = (network: KnownNetworksType) => {
   return {
-    "argent-version": process.env.VERSION || "",
+    "argent-version": process.env.VERSION || "Unknown version",
     "argent-client": "argent-x",
     "argent-network": argentApiNetworkForNetwork(network),
   }

--- a/packages/extension/src/shared/tokenPrice.service.ts
+++ b/packages/extension/src/shared/tokenPrice.service.ts
@@ -1,7 +1,5 @@
 import CurrencyConversionNumber from "bignumber.js"
 import { BigNumber, BigNumberish, utils } from "ethers"
-import { isString } from "lodash-es"
-import urlJoin from "url-join"
 
 import { TokenDetailsWithBalance } from "../ui/features/accountTokens/tokens.state"
 import { UniqueToken } from "./token"
@@ -10,19 +8,6 @@ import {
   prettifyCurrencyNumber,
   prettifyTokenNumber,
 } from "./utils/number"
-
-const ARGENT_API_BASE_URL = process.env.ARGENT_API_BASE_URL as string
-
-export const ARGENT_API_ENABLED =
-  isString(ARGENT_API_BASE_URL) && ARGENT_API_BASE_URL.length > 0
-
-export const ARGENT_API_TOKENS_PRICES_URL = ARGENT_API_ENABLED
-  ? urlJoin(ARGENT_API_BASE_URL, "tokens/prices?chain=starknet")
-  : undefined
-
-export const ARGENT_API_TOKENS_INFO_URL = ARGENT_API_ENABLED
-  ? urlJoin(ARGENT_API_BASE_URL, "tokens/info?chain=starknet")
-  : undefined
 
 /** shape of individual entity in the /tokens/info endpoint */
 export interface ApiTokenDetails {

--- a/packages/extension/src/shared/transactionReview.service.ts
+++ b/packages/extension/src/shared/transactionReview.service.ts
@@ -1,23 +1,8 @@
-import { isArray, isString } from "lodash-es"
+import { isArray } from "lodash-es"
 import { Call } from "starknet"
-import urlJoin from "url-join"
 
-import { fetcher } from "./utils/fetcher"
-
-const ARGENT_TRANSACTION_REVIEW_API_BASE_URL = process.env
-  .ARGENT_TRANSACTION_REVIEW_API_BASE_URL as string
-
-export const ARGENT_TRANSACTION_REVIEW_API_ENABLED =
-  isString(ARGENT_TRANSACTION_REVIEW_API_BASE_URL) &&
-  ARGENT_TRANSACTION_REVIEW_API_BASE_URL.length > 0
-
-export const ARGENT_TRANSACTION_REVIEW_STARKNET_URL =
-  ARGENT_TRANSACTION_REVIEW_API_ENABLED
-    ? urlJoin(
-        ARGENT_TRANSACTION_REVIEW_API_BASE_URL,
-        "transactions/review/starknet",
-      )
-    : undefined
+import { ARGENT_TRANSACTION_REVIEW_STARKNET_URL } from "./api/constants"
+import { Fetcher, fetcher } from "./api/fetcher"
 
 export type ApiTransactionReviewAssessment =
   | "warn"
@@ -93,12 +78,14 @@ export interface IFetchTransactionReview {
   network: ApiTransactionReviewNetwork
   accountAddress: string
   transactions: Call | Call[]
+  fetcher?: Fetcher
 }
 
 export const fetchTransactionReview = ({
   network,
   accountAddress,
   transactions,
+  fetcher: fetcherImpl = fetcher,
 }: IFetchTransactionReview) => {
   if (!ARGENT_TRANSACTION_REVIEW_STARKNET_URL) {
     throw "Transaction review endpoint is not defined"
@@ -109,7 +96,7 @@ export const fetchTransactionReview = ({
     account: accountAddress,
     calls,
   }
-  return fetcher(ARGENT_TRANSACTION_REVIEW_STARKNET_URL, {
+  return fetcherImpl(ARGENT_TRANSACTION_REVIEW_STARKNET_URL, {
     method: "POST",
     headers: {
       Accept: "application/json",

--- a/packages/extension/src/shared/utils/fetcher.ts
+++ b/packages/extension/src/shared/utils/fetcher.ts
@@ -1,7 +1,0 @@
-/** generic json fetcher */
-
-export const fetcher = async (input: RequestInfo | URL, init?: RequestInit) => {
-  const response = await fetch(input, init)
-  const json = await response.json()
-  return json
-}

--- a/packages/extension/src/ui/features/accountTokens/tokenPriceHooks.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokenPriceHooks.ts
@@ -1,20 +1,22 @@
 import { BigNumberish } from "ethers"
 import { useMemo } from "react"
 
-import { isPrivacySettingsEnabled } from "../../../shared/settings"
-import { Token } from "../../../shared/token"
 import {
   ARGENT_API_ENABLED,
   ARGENT_API_TOKENS_INFO_URL,
   ARGENT_API_TOKENS_PRICES_URL,
+} from "../../../shared/api/constants"
+import { isPrivacySettingsEnabled } from "../../../shared/settings"
+import { Token } from "../../../shared/token"
+import {
   ApiPriceDataResponse,
   ApiTokenDataResponse,
   convertTokenAmountToCurrencyValue,
   lookupTokenPriceDetails,
   sumTokenBalancesToCurrencyValue,
 } from "../../../shared/tokenPrice.service"
-import { fetcher } from "../../../shared/utils/fetcher"
 import { useConditionallyEnabledSWR } from "../../services/swr"
+import { useArgentApiFetcher } from "../../services/useArgentApiFetcher"
 import { useBackgroundSettingsValue } from "../../services/useBackgroundSettingsValue"
 import { useIsMainnet } from "../networks/useNetworks"
 import { TokenDetails, TokenDetailsWithBalance } from "./tokens.state"
@@ -36,6 +38,7 @@ export const useCurrencyDisplayEnabled = () => {
 /** @returns price and token data which will be cached and refreshed periodically by SWR */
 
 export const usePriceAndTokenDataFromApi = () => {
+  const fetcher = useArgentApiFetcher()
   const currencyDisplayEnabled = useCurrencyDisplayEnabled()
   const { data: pricesData } = useConditionallyEnabledSWR<ApiPriceDataResponse>(
     currencyDisplayEnabled,

--- a/packages/extension/src/ui/features/actions/transaction/useTransactionReview.ts
+++ b/packages/extension/src/ui/features/actions/transaction/useTransactionReview.ts
@@ -1,13 +1,16 @@
 import { useCallback } from "react"
 import { Call } from "starknet"
 
+import { ARGENT_TRANSACTION_REVIEW_API_ENABLED } from "../../../../shared/api/constants"
+import { argentApiNetworkForNetwork } from "../../../../shared/api/fetcher"
+import { KnownNetworksType } from "../../../../shared/networks"
 import { isPrivacySettingsEnabled } from "../../../../shared/settings"
 import {
-  ARGENT_TRANSACTION_REVIEW_API_ENABLED,
   ApiTransactionReviewResponse,
   fetchTransactionReview,
 } from "../../../../shared/transactionReview.service"
 import { useConditionallyEnabledSWR } from "../../../services/swr"
+import { useArgentApiFetcher } from "../../../services/useArgentApiFetcher"
 import { useBackgroundSettingsValue } from "../../../services/useBackgroundSettingsValue"
 import { Account } from "../../accounts/Account"
 
@@ -35,17 +38,21 @@ export const useTransactionReview = ({
   transactions,
   actionHash,
 }: IUseTransactionReview) => {
+  const fetcher = useArgentApiFetcher()
   const transactionReviewEnabled = useTransactionReviewEnabled()
   const transactionReviewFetcher = useCallback(async () => {
     if (!account) {
       return
     }
-    const network = account.networkId === "goerli-alpha" ? "goerli" : "mainnet"
+    const network = argentApiNetworkForNetwork(
+      account.networkId as KnownNetworksType,
+    )
     const accountAddress = account.address
     return fetchTransactionReview({
       network,
       accountAddress,
       transactions,
+      fetcher,
     })
   }, [account, transactions])
   return useConditionallyEnabledSWR<ApiTransactionReviewResponse>(

--- a/packages/extension/src/ui/index.tsx
+++ b/packages/extension/src/ui/index.tsx
@@ -2,8 +2,10 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { BrowserRouter } from "react-router-dom"
 
-import { ARGENT_API_ENABLED } from "../shared/tokenPrice.service"
-import { ARGENT_TRANSACTION_REVIEW_API_ENABLED } from "../shared/transactionReview.service"
+import {
+  ARGENT_API_ENABLED,
+  ARGENT_TRANSACTION_REVIEW_API_ENABLED,
+} from "../shared/api/constants"
 import { App } from "./App"
 
 const container = document.getElementById("root")

--- a/packages/extension/src/ui/services/useArgentApiFetcher.ts
+++ b/packages/extension/src/ui/services/useArgentApiFetcher.ts
@@ -1,0 +1,22 @@
+import { useMemo } from "react"
+
+import { fetcherWithArgentApiHeadersForNetwork } from "../../shared/api/fetcher"
+import { KnownNetworksType } from "../../shared/networks"
+import { useAppState } from "../app.state"
+
+/**
+ * Returns an SWR-compliant fetcher which will apply the expected API headers to each request,
+ * including the currently selected network
+ *
+ * @see fetcherWithArgentApiHeadersForNetwork
+ */
+
+export const useArgentApiFetcher = () => {
+  const { switcherNetworkId } = useAppState()
+  const fetcher = useMemo(() => {
+    return fetcherWithArgentApiHeadersForNetwork(
+      switcherNetworkId as KnownNetworksType,
+    )
+  }, [switcherNetworkId])
+  return fetcher
+}

--- a/packages/extension/test/fetcher.test.ts
+++ b/packages/extension/test/fetcher.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from "vitest"
+
+import { fetcherWithArgentApiHeadersForNetwork } from "../src/shared/api/fetcher"
+
+describe("fetcher", () => {
+  describe("fetcherWithArgentApiHeadersForNetwork()", () => {
+    const ORIGINAL_PROCESS_ENV = process.env
+    const MOCK_VERSION = "testing.1.2.3"
+    const fetcher = vi.fn(async () => "foo")
+    const fetcherWithArgentApiHeaders = fetcherWithArgentApiHeadersForNetwork(
+      "goerli-alpha",
+      fetcher,
+    )
+
+    beforeAll(() => {
+      process.env = {
+        VERSION: MOCK_VERSION,
+      }
+    })
+
+    afterAll(() => {
+      process.env = ORIGINAL_PROCESS_ENV
+    })
+
+    describe("when no options set", () => {
+      test("should provide the expected API headers to underlying fetcher", async () => {
+        expect(fetcherWithArgentApiHeaders("/foo/bar")).resolves.toEqual("foo")
+        expect(fetcher).toHaveBeenLastCalledWith("/foo/bar", {
+          headers: {
+            "argent-version": MOCK_VERSION,
+            "argent-client": "argent-x",
+            "argent-network": "goerli",
+          },
+        })
+      })
+    })
+    describe("when options set", () => {
+      test("should provide the expected API headers to underlying fetcher", async () => {
+        expect(
+          fetcherWithArgentApiHeaders("/foo/bar", {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+            },
+            body: "foo",
+          }),
+        ).resolves.toEqual("foo")
+        expect(fetcher).toHaveBeenLastCalledWith("/foo/bar", {
+          body: "foo",
+          headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json",
+            "argent-version": MOCK_VERSION,
+            "argent-client": "argent-x",
+            "argent-network": "goerli",
+          },
+          method: "POST",
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds functions and tests for adding the expected Argent headers to Argent API requests, including the currently selected network.

The core feature is a new hook `useArgentApiFetcher()` which returns an SWR-compatible `fetcher` which adds the expected headers to all requests, adjusting for network changes automatically.

The spec is that requests sent to Argent API services should include the following http headers:

`argent-version` - e.g. `4.1.7`
`argent-client` - `argent-x`
`argent-network` - e.g. `goerli` or `mainnet`