### PR TITLE
feat: refactor account list item into reusable component + storybooks

### DIFF
--- a/packages/extension/src/ui/features/accounts/AccountColumn.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountColumn.tsx
@@ -1,6 +1,0 @@
-import styled from "styled-components"
-
-export const AccountColumn = styled.div`
-  display: flex;
-  flex-direction: column;
-`

--- a/packages/extension/src/ui/features/accounts/AccountListItem.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListItem.tsx
@@ -1,39 +1,24 @@
-import { FC } from "react"
-import { useNavigate } from "react-router-dom"
-import styled, { css } from "styled-components"
-import useSWR from "swr"
+import { FC, ReactNode } from "react"
+import styled from "styled-components"
 
-import { BaseWalletAccount } from "../../../shared/wallet.model"
-import {
-  getAccountIdentifier,
-  isDeprecated,
-} from "../../../shared/wallet.service"
-import { useAppState } from "../../app.state"
 import { ArrowCircleDownIcon } from "../../components/Icons/MuiIcons"
 import { TransactionStatusIndicator } from "../../components/StatusIndicator"
-import { routes } from "../../routes"
-import { makeClickable } from "../../services/a11y"
 import { formatTruncatedAddress } from "../../services/addresses"
-import { fetchFeeTokenBalance } from "../accountTokens/tokens.service"
-import { useAccountStatus } from "../accountTokens/useAccountStatus"
 import { NetworkStatusWrapper } from "../networks/NetworkSwitcher"
-import { useNetwork } from "../networks/useNetworks"
-import { Account } from "./Account"
-import { AccountColumn } from "./AccountColumn"
-import { getAccountName, useAccountMetadata } from "./accountMetadata.state"
-import { AccountRow } from "./AccountRow"
-import { getAccountImageUrl } from "./accounts.service"
-import { useAccounts } from "./accounts.state"
+import { getNetworkAccountImageUrl } from "./accounts.service"
 import { ProfilePicture } from "./ProfilePicture"
-import { checkIfUpgradeAvailable } from "./upgrade.service"
 
 export const AccountListItemWrapper = styled.div<{
-  selected?: boolean
+  outline?: boolean
+  highlight?: boolean
 }>`
   cursor: pointer;
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: ${({ highlight }) =>
+    highlight ? "rgba(255, 255, 255, 0.15)" : "rgba(255, 255, 255, 0.1)"};
   border-radius: 4px;
   padding: 20px 16px;
+  border: 1px solid
+    ${({ outline }) => (outline ? "rgba(255, 255, 255, 0.3)" : "transparent")};
 
   display: flex;
   gap: 12px;
@@ -41,17 +26,23 @@ export const AccountListItemWrapper = styled.div<{
 
   transition: all 200ms ease-in-out;
 
-  ${({ selected = false }) =>
-    selected &&
-    css`
-      border: 1px solid rgba(255, 255, 255, 0.3);
-    `}
-
   &:hover,
   &:focus {
     background: rgba(255, 255, 255, 0.15);
     outline: 0;
   }
+`
+
+const AccountColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const AccountRow = styled.div`
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: space-between;
 `
 
 const AccountStatusText = styled.p`
@@ -68,74 +59,68 @@ const AccountName = styled.h1`
   margin: 0 0 5px 0;
 `
 
-interface AccountListProps {
-  account: Account
-  selectedAccount?: BaseWalletAccount
-  canShowUpgrade?: boolean
+const AccountAddress = styled.div`
+  font-size: 13px;
+`
+
+export interface IAccountListItem {
+  accountName: string
+  accountAddress: string
+  networkId: string
+  outline?: boolean
+  highlight?: boolean
+  deploying?: boolean
+  upgrade?: boolean
+  children?: ReactNode
+  // ...rest
+  [x: string]: any
 }
 
-export const AccountListItem: FC<AccountListProps> = ({
-  account,
-  selectedAccount,
-  canShowUpgrade,
+export const AccountListItem: FC<IAccountListItem> = ({
+  accountName,
+  accountAddress,
+  networkId,
+  outline,
+  highlight,
+  deploying,
+  upgrade,
+  children,
+  ...rest
 }) => {
-  const navigate = useNavigate()
-  const { switcherNetworkId } = useAppState()
-  const {
-    network: { accountClassHash },
-  } = useNetwork(switcherNetworkId)
-  const status = useAccountStatus(account, selectedAccount)
-
-  const { accountNames } = useAccountMetadata()
-  const accountName = getAccountName(account, accountNames)
-
-  const { data: feeTokenBalance } = useSWR(
-    [getAccountIdentifier(account), switcherNetworkId, "feeTokenBalance"],
-    () => fetchFeeTokenBalance(account, switcherNetworkId),
-    { suspense: false },
-  )
-
-  const { data: needsUpgrade = false } = useSWR(
-    [getAccountIdentifier(account), accountClassHash, "showUpgradeBanner"],
-    () => checkIfUpgradeAvailable(account, accountClassHash),
-    { suspense: false },
-  )
-
-  const showUpgradeBanner = Boolean(needsUpgrade && feeTokenBalance?.gt(0))
-
   return (
-    <AccountListItemWrapper
-      {...makeClickable(() => {
-        useAccounts.setState({
-          selectedAccount: account,
-          showMigrationScreen: account ? isDeprecated(account) : false,
-        })
-        navigate(routes.accountTokens())
-      })}
-      selected={status.code === "CONNECTED"}
-    >
-      <ProfilePicture src={getAccountImageUrl(accountName, account)} />
+    <AccountListItemWrapper outline={outline} highlight={highlight} {...rest}>
+      <ProfilePicture
+        src={getNetworkAccountImageUrl({
+          accountName,
+          accountAddress,
+          networkId,
+        })}
+      />
       <AccountRow>
         <AccountColumn>
           <AccountName>{accountName}</AccountName>
-          <p>{formatTruncatedAddress(account.address)}</p>
+          <AccountAddress>
+            {formatTruncatedAddress(accountAddress)}
+          </AccountAddress>
         </AccountColumn>
-        {status.code === "DEPLOYING" ? (
-          <NetworkStatusWrapper>
-            <TransactionStatusIndicator color="orange" />
-            <AccountStatusText>Deploying</AccountStatusText>
-          </NetworkStatusWrapper>
-        ) : (
-          canShowUpgrade &&
-          showUpgradeBanner && (
+        <AccountColumn>
+          {deploying ? (
             <NetworkStatusWrapper>
-              <ArrowCircleDownIcon
-                style={{ maxHeight: "16px", maxWidth: "16px" }}
-              />
-              <AccountStatusText>Upgrade</AccountStatusText>
+              <TransactionStatusIndicator color="orange" />
+              <AccountStatusText>Deploying</AccountStatusText>
             </NetworkStatusWrapper>
-          )
-        )}
+          ) : (
+            upgrade && (
+              <NetworkStatusWrapper>
+                <ArrowCircleDownIcon
+                  style={{ maxHeight: "16px", maxWidth: "16px" }}
+                />
+                <AccountStatusText>Upgrade</AccountStatusText>
+              </NetworkStatusWrapper>
+            )
+          )}
+          {children}
+        </AccountColumn>
       </AccountRow>
     </AccountListItemWrapper>
   )

--- a/packages/extension/src/ui/features/accounts/AccountListItem.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListItem.tsx
@@ -8,10 +8,25 @@ import { NetworkStatusWrapper } from "../networks/NetworkSwitcher"
 import { getNetworkAccountImageUrl } from "./accounts.service"
 import { ProfilePicture } from "./ProfilePicture"
 
-export const AccountListItemWrapper = styled.div<{
+export interface IAccountListItem {
+  accountName: string
+  accountAddress: string
+  networkId: string
   outline?: boolean
   highlight?: boolean
-}>`
+  deploying?: boolean
+  upgrade?: boolean
+  children?: ReactNode
+  // ...rest
+  [x: string]: any
+}
+
+type AccountListItemWrapperProps = Pick<
+  IAccountListItem,
+  "highlight" | "outline"
+>
+
+export const AccountListItemWrapper = styled.div<AccountListItemWrapperProps>`
   cursor: pointer;
   background-color: ${({ highlight }) =>
     highlight ? "rgba(255, 255, 255, 0.15)" : "rgba(255, 255, 255, 0.1)"};
@@ -62,19 +77,6 @@ const AccountName = styled.h1`
 const AccountAddress = styled.div`
   font-size: 13px;
 `
-
-export interface IAccountListItem {
-  accountName: string
-  accountAddress: string
-  networkId: string
-  outline?: boolean
-  highlight?: boolean
-  deploying?: boolean
-  upgrade?: boolean
-  children?: ReactNode
-  // ...rest
-  [x: string]: any
-}
 
 export const AccountListItem: FC<IAccountListItem> = ({
   accountName,

--- a/packages/extension/src/ui/features/accounts/AccountListScreen.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListScreen.tsx
@@ -18,7 +18,7 @@ import { recover } from "../recovery/recovery.service"
 import { RecoveryBanner } from "../recovery/RecoveryBanner"
 import { Container } from "./AccountContainer"
 import { AccountHeader } from "./AccountHeader"
-import { AccountListItem } from "./AccountListItem"
+import { AccountListScreenItem } from "./AccountListScreenItem"
 import { deployAccount } from "./accounts.service"
 import { useAccounts } from "./accounts.state"
 import { DeprecatedAccountsWarning } from "./DeprecatedAccountsWarning"
@@ -103,7 +103,7 @@ export const AccountListScreen: FC = () => {
           </Paragraph>
         )}
         {newAccounts.map((account) => (
-          <AccountListItem
+          <AccountListScreenItem
             key={account.address}
             account={account}
             selectedAccount={selectedAccount}
@@ -114,7 +114,7 @@ export const AccountListScreen: FC = () => {
           <>
             <DeprecatedAccountsWarning />
             {deprecatedAccounts.map((account) => (
-              <AccountListItem
+              <AccountListScreenItem
                 key={account.address}
                 account={account}
                 selectedAccount={selectedAccount}

--- a/packages/extension/src/ui/features/accounts/AccountListScreenItem.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListScreenItem.tsx
@@ -1,0 +1,74 @@
+import { FC } from "react"
+import { useNavigate } from "react-router-dom"
+import useSWR from "swr"
+
+import { BaseWalletAccount } from "../../../shared/wallet.model"
+import {
+  getAccountIdentifier,
+  isDeprecated,
+} from "../../../shared/wallet.service"
+import { useAppState } from "../../app.state"
+import { routes } from "../../routes"
+import { makeClickable } from "../../services/a11y"
+import { fetchFeeTokenBalance } from "../accountTokens/tokens.service"
+import { useAccountStatus } from "../accountTokens/useAccountStatus"
+import { useNetwork } from "../networks/useNetworks"
+import { Account } from "./Account"
+import { AccountListItem } from "./AccountListItem"
+import { getAccountName, useAccountMetadata } from "./accountMetadata.state"
+import { useAccounts } from "./accounts.state"
+import { checkIfUpgradeAvailable } from "./upgrade.service"
+
+interface IAccountListScreenItem {
+  account: Account
+  selectedAccount?: BaseWalletAccount
+  canShowUpgrade?: boolean
+}
+
+export const AccountListScreenItem: FC<IAccountListScreenItem> = ({
+  account,
+  selectedAccount,
+  canShowUpgrade,
+}) => {
+  const navigate = useNavigate()
+  const { switcherNetworkId } = useAppState()
+  const {
+    network: { accountClassHash },
+  } = useNetwork(switcherNetworkId)
+  const status = useAccountStatus(account, selectedAccount)
+
+  const { accountNames } = useAccountMetadata()
+  const accountName = getAccountName(account, accountNames)
+
+  const { data: feeTokenBalance } = useSWR(
+    [getAccountIdentifier(account), switcherNetworkId, "feeTokenBalance"],
+    () => fetchFeeTokenBalance(account, switcherNetworkId),
+    { suspense: false },
+  )
+
+  const { data: needsUpgrade = false } = useSWR(
+    [getAccountIdentifier(account), accountClassHash, "showUpgradeBanner"],
+    () => checkIfUpgradeAvailable(account, accountClassHash),
+    { suspense: false },
+  )
+
+  const showUpgradeBanner = Boolean(needsUpgrade && feeTokenBalance?.gt(0))
+
+  return (
+    <AccountListItem
+      {...makeClickable(() => {
+        useAccounts.setState({
+          selectedAccount: account,
+          showMigrationScreen: account ? isDeprecated(account) : false,
+        })
+        navigate(routes.accountTokens())
+      })}
+      accountName={accountName}
+      accountAddress={account.address}
+      networkId={account.networkId}
+      outline={status.code === "CONNECTED"}
+      deploying={status.code === "DEPLOYING"}
+      upgrade={canShowUpgrade && showUpgradeBanner}
+    />
+  )
+}

--- a/packages/extension/src/ui/features/accounts/AccountRow.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountRow.tsx
@@ -1,8 +1,0 @@
-import styled from "styled-components"
-
-export const AccountRow = styled.div`
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-`

--- a/packages/extension/src/ui/features/accounts/accounts.service.ts
+++ b/packages/extension/src/ui/features/accounts/accounts.service.ts
@@ -34,11 +34,28 @@ export const getColor = (name: string) => {
 }
 
 export const getAccountImageUrl = (
-  name: string,
+  accountName: string,
   account: BaseWalletAccount,
 ) => {
-  const color = getColor(getAccountIdentifier(account))
-  return `https://eu.ui-avatars.com/api?name=${name}&background=${color}&color=fff`
+  return getNetworkAccountImageUrl({
+    accountName,
+    networkId: account.networkId,
+    accountAddress: account.address,
+  })
+}
+
+export const getNetworkAccountImageUrl = ({
+  accountName,
+  networkId,
+  accountAddress,
+}: {
+  accountName: string
+  networkId: string
+  accountAddress: string
+}) => {
+  const accountIdentifier = `${networkId}::${accountAddress}`
+  const color = getColor(accountIdentifier)
+  return `https://eu.ui-avatars.com/api?name=${accountName}&background=${color}&color=fff`
 }
 
 const isAccountDeployed = (account: Account): boolean =>

--- a/packages/storybook/src/features/accounts/AccountListItem.stories.tsx
+++ b/packages/storybook/src/features/accounts/AccountListItem.stories.tsx
@@ -1,0 +1,53 @@
+import { AccountListItem } from "@argent-x/extension/src/ui/features/accounts/AccountListItem"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+
+export default {
+  title: "accounts/AccountListItem",
+  component: AccountListItem,
+} as ComponentMeta<typeof AccountListItem>
+
+const Template: ComponentStory<typeof AccountListItem> = (props) => (
+  <AccountListItem {...props}></AccountListItem>
+)
+
+const account = {
+  accountName: "Account 1",
+  accountAddress:
+    "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a",
+  networkId: "goerli-alpha",
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  ...account,
+}
+
+export const Outline = Template.bind({})
+Outline.args = {
+  ...account,
+  outline: true,
+}
+
+export const Highlight = Template.bind({})
+Highlight.args = {
+  ...account,
+  highlight: true,
+}
+
+export const Deploying = Template.bind({})
+Deploying.args = {
+  ...account,
+  deploying: true,
+}
+
+export const Upgrade = Template.bind({})
+Upgrade.args = {
+  ...account,
+  upgrade: true,
+}
+
+export const Children = Template.bind({})
+Children.args = {
+  ...account,
+  children: <span>Child in here</span>,
+}


### PR DESCRIPTION
Splits the visual part of AccountListItem into a separate stateless reusable component suitable for use in forthcoming features where user is picking from a list of accounts.

<img width="337" alt="Screenshot 2022-07-11 at 14 22 33" src="https://user-images.githubusercontent.com/175607/178274095-800e7a2a-065c-446b-b04c-c4c4f91e8847.png">

<img width="336" alt="Screenshot 2022-07-11 at 14 22 27" src="https://user-images.githubusercontent.com/175607/178274082-e62b45df-b68f-4038-b897-78c994495438.png">
