### PR TITLE
Feat/hidden accounts

### DIFF
--- a/packages/extension/src/background/accountMessaging.ts
+++ b/packages/extension/src/background/accountMessaging.ts
@@ -130,6 +130,17 @@ export const handleAccountMessage: HandleMessage<AccountMessage> = async ({
       }
     }
 
+    case "UNHIDE_ACCOUNT": {
+      try {
+        await wallet.unhideAccount(msg.data)
+        return sendToTabAndUi({
+          type: "UNHIDE_ACCOUNT_RES",
+        })
+      } catch {
+        return sendToTabAndUi({ type: "UNHIDE_ACCOUNT_REJ" })
+      }
+    }
+
     case "GET_ENCRYPTED_PRIVATE_KEY": {
       if (!wallet.isSessionOpen()) {
         throw Error("you need an open session")

--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -224,6 +224,11 @@ export class Wallet {
     return uniqueAccounts.filter((account) => includeHidden || !account.hidden)
   }
 
+  public async getHiddenAccounts() {
+    const accounts = await this.getAccounts(true)
+    return accounts.filter((account) => !!account.hidden)
+  }
+
   private async addWalletAccounts(accounts: WalletAccount[]) {
     const oldAccounts = await this.getAccounts(true)
 
@@ -249,7 +254,15 @@ export class Wallet {
   }
 
   public async hideAccount(account: BaseWalletAccount) {
-    const accounts = await this.getAccounts()
+    return this.setAccountHidden(account, true)
+  }
+
+  public async unhideAccount(account: BaseWalletAccount) {
+    return this.setAccountHidden(account, false)
+  }
+
+  public async setAccountHidden(account: BaseWalletAccount, hidden: boolean) {
+    const accounts = await this.getAccounts(true)
 
     const fullAccount = find(accounts, (a) => accountsEqual(a, account))
 
@@ -259,7 +272,7 @@ export class Wallet {
 
     const hiddenAccount: WalletAccount = {
       ...fullAccount,
-      hidden: true,
+      hidden,
     }
 
     const newAccounts = mergeArrayStableWith(

--- a/packages/extension/src/shared/messages/AccountMessage.ts
+++ b/packages/extension/src/shared/messages/AccountMessage.ts
@@ -25,6 +25,9 @@ export type AccountMessage =
   | { type: "HIDE_ACCOUNT"; data: BaseWalletAccount }
   | { type: "HIDE_ACCOUNT_RES" }
   | { type: "HIDE_ACCOUNT_REJ" }
+  | { type: "UNHIDE_ACCOUNT"; data: BaseWalletAccount }
+  | { type: "UNHIDE_ACCOUNT_RES" }
+  | { type: "UNHIDE_ACCOUNT_REJ" }
   | {
       type: "UPGRADE_ACCOUNT"
       data: BaseWalletAccount

--- a/packages/extension/src/ui/AppRoutes.tsx
+++ b/packages/extension/src/ui/AppRoutes.tsx
@@ -6,6 +6,7 @@ import { useAppState } from "./app.state"
 import { TransactionDetail } from "./features/accountActivity/TransactionDetail"
 import { NftScreen } from "./features/accountNfts/NftScreen"
 import { SendNftScreen } from "./features/accountNfts/SendNftScreen"
+import { AccountListHiddenScreen } from "./features/accounts/AccountListHiddenScreen"
 import { AccountListScreen } from "./features/accounts/AccountListScreen"
 import { AccountScreen } from "./features/accounts/AccountScreen"
 import { HideOrDeleteAccountConfirmScreen } from "./features/accounts/HideOrDeleteAccountConfirmScreen"
@@ -141,6 +142,10 @@ const walletRoutes = (
     <Route path={routes.sendNft.path} element={<SendNftScreen />} />
     <Route path={routes.upgrade.path} element={<UpgradeScreen />} />
     <Route path={routes.accounts.path} element={<AccountListScreen />} />
+    <Route
+      path={routes.accountsHidden.path}
+      element={<AccountListHiddenScreen />}
+    />
     <Route path={routes.funding.path} element={<FundingScreen />} />
     <Route path={routes.fundingQrCode.path} element={<FundingQrCodeScreen />} />
     <Route

--- a/packages/extension/src/ui/components/Icons/MuiIcons.ts
+++ b/packages/extension/src/ui/components/Icons/MuiIcons.ts
@@ -22,4 +22,5 @@ export { default as ReportGmailerrorredIcon } from "@mui/icons-material/ReportGm
 export { default as ReportGmailerrorredRoundedIcon } from "@mui/icons-material/ReportGmailerrorredRounded"
 export { default as SendIcon } from "@mui/icons-material/Send"
 export { default as SettingsIcon } from "@mui/icons-material/Settings"
+export { default as VisibilityIcon } from "@mui/icons-material/Visibility"
 export { default as VisibilityOff } from "@mui/icons-material/VisibilityOff"

--- a/packages/extension/src/ui/features/accounts/Account.ts
+++ b/packages/extension/src/ui/features/accounts/Account.ts
@@ -20,17 +20,26 @@ export class Account {
   contract: Contract
   proxyContract: Contract
   provider: ProviderInterface
+  hidden?: boolean
 
-  constructor(
-    address: string,
-    network: Network,
-    signer: WalletAccountSigner,
-    deployTransaction?: string,
-  ) {
+  constructor({
+    address,
+    network,
+    signer,
+    deployTransaction,
+    hidden,
+  }: {
+    address: string
+    network: Network
+    signer: WalletAccountSigner
+    deployTransaction?: string
+    hidden?: boolean
+  }) {
     this.address = address
     this.network = network
     this.networkId = network.id
     this.signer = signer
+    this.hidden = hidden
     this.deployTransaction = deployTransaction
     this.provider = getProvider(network)
     this.contract = new Contract(
@@ -93,12 +102,12 @@ export class Account {
       throw new Error(`Network ${networkId} not found`)
     }
 
-    return new Account(
-      result.address,
+    return new Account({
+      address: result.address,
       network,
-      result.account.signer,
-      result.txHash,
-    )
+      signer: result.account.signer,
+      deployTransaction: result.txHash,
+    })
   }
 
   public toWalletAccount(): WalletAccount {

--- a/packages/extension/src/ui/features/accounts/AccountListHiddenScreen.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListHiddenScreen.tsx
@@ -1,0 +1,53 @@
+import { FC } from "react"
+import { Navigate } from "react-router-dom"
+import styled from "styled-components"
+
+import { IconBar } from "../../components/IconBar"
+import { routes } from "../../routes"
+import { H1 } from "../../theme/Typography"
+import { Container } from "./AccountContainer"
+import { AccountListHiddenScreenItem } from "./AccountListHiddenScreenItem"
+import { useHiddenAccounts } from "./accounts.state"
+
+const AccountList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 48px 32px;
+`
+
+const AccountListWrapper = styled(Container)`
+  display: flex;
+  flex-direction: column;
+
+  ${H1} {
+    text-align: center;
+  }
+
+  > ${AccountList} {
+    width: 100%;
+  }
+`
+
+export const AccountListHiddenScreen: FC = () => {
+  const hiddenAccounts = useHiddenAccounts()
+  const hiddenAccountsList = Object.values(hiddenAccounts)
+  const hasHiddenAccounts = Object.values(hiddenAccounts).length > 0
+  if (!hasHiddenAccounts) {
+    return <Navigate to={routes.accounts()} />
+  }
+  return (
+    <AccountListWrapper>
+      <IconBar back />
+      <H1>Hidden Accounts</H1>
+      <AccountList>
+        {hiddenAccountsList.map((account) => (
+          <AccountListHiddenScreenItem
+            key={account.address}
+            account={account}
+          />
+        ))}
+      </AccountList>
+    </AccountListWrapper>
+  )
+}

--- a/packages/extension/src/ui/features/accounts/AccountListHiddenScreenItem.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListHiddenScreenItem.tsx
@@ -1,0 +1,33 @@
+import { FC } from "react"
+
+import { makeClickable } from "../../services/a11y"
+import { unhideAccount } from "../../services/backgroundAccounts"
+import { updateAccountsStateFromWallet } from "../recovery/recovery.service"
+import { Account } from "./Account"
+import { AccountListItem } from "./AccountListItem"
+import { getAccountName, useAccountMetadata } from "./accountMetadata.state"
+
+interface IAccountListHiddenScreenItem {
+  account: Account
+}
+
+export const AccountListHiddenScreenItem: FC<IAccountListHiddenScreenItem> = ({
+  account,
+}) => {
+  const { accountNames } = useAccountMetadata()
+  const accountName = getAccountName(account, accountNames)
+  return (
+    <AccountListItem
+      {...makeClickable(async () => {
+        // update the state in the wallet
+        await unhideAccount(account.address, account.networkId)
+        // TODO: refactor - currently explicit sync wallet state into UI store, should be reactive
+        await updateAccountsStateFromWallet(account.networkId)
+      })}
+      accountName={accountName}
+      accountAddress={account.address}
+      networkId={account.networkId}
+      hidden
+    />
+  )
+}

--- a/packages/extension/src/ui/features/accounts/AccountListItem.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListItem.tsx
@@ -1,12 +1,15 @@
 import { FC, ReactNode } from "react"
 import styled from "styled-components"
 
-import { ArrowCircleDownIcon, LinkIcon } from "../../components/Icons/MuiIcons"
+import {
+  ArrowCircleDownIcon,
+  LinkIcon,
+  VisibilityIcon,
+} from "../../components/Icons/MuiIcons"
 import { TransactionStatusIndicator } from "../../components/StatusIndicator"
 import { formatTruncatedAddress } from "../../services/addresses"
 import { NetworkStatusWrapper } from "../networks/NetworkSwitcher"
 import { getNetworkAccountImageUrl } from "./accounts.service"
-import { ProfilePicture } from "./ProfilePicture"
 
 export interface IAccountListItem {
   accountName: string
@@ -18,18 +21,21 @@ export interface IAccountListItem {
   upgrade?: boolean
   connected?: boolean
   transparent?: boolean
+  hidden?: boolean
   children?: ReactNode
 }
 
 type AccountListItemWrapperProps = Pick<
   IAccountListItem,
   "highlight" | "outline" | "transparent"
->
+> & {
+  dark?: boolean
+}
 
 export const AccountListItemWrapper = styled.div<AccountListItemWrapperProps>`
   cursor: pointer;
-  background-color: ${({ highlight, transparent }) =>
-    transparent
+  background-color: ${({ highlight, transparent, dark }) =>
+    transparent || dark
       ? "transparent"
       : highlight
       ? "rgba(255, 255, 255, 0.15)"
@@ -37,7 +43,8 @@ export const AccountListItemWrapper = styled.div<AccountListItemWrapperProps>`
   border-radius: 4px;
   padding: 20px 16px;
   border: 1px solid
-    ${({ outline }) => (outline ? "rgba(255, 255, 255, 0.3)" : "transparent")};
+    ${({ outline, dark }) =>
+      outline || dark ? "rgba(255, 255, 255, 0.3)" : "transparent"};
 
   display: flex;
   gap: 12px;
@@ -47,10 +54,20 @@ export const AccountListItemWrapper = styled.div<AccountListItemWrapperProps>`
 
   &:hover,
   &:focus {
-    background: ${({ transparent }) =>
-      transparent ? "transparent" : "rgba(255, 255, 255, 0.15)"};
+    background: ${({ transparent, dark }) =>
+      transparent
+        ? "transparent"
+        : dark
+        ? "rgba(255, 255, 255, 0.1)"
+        : "rgba(255, 255, 255, 0.15)"};
     outline: 0;
   }
+`
+
+const AccountAvatar = styled.img`
+  border-radius: 500px;
+  width: 40px;
+  height: 40px;
 `
 
 const AccountColumn = styled.div`
@@ -97,6 +114,16 @@ const ConnectedIcon = styled(LinkIcon)`
   font-size: 16px;
 `
 
+const HiddenStatusWrapper = styled.div`
+  background-color: ${({ theme }) => theme.bg2};
+  width: 40px;
+  height: 40px;
+  border-radius: 500px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
 export const AccountListItem: FC<IAccountListItem> = ({
   accountName,
   accountAddress,
@@ -104,16 +131,18 @@ export const AccountListItem: FC<IAccountListItem> = ({
   deploying,
   upgrade,
   connected,
+  hidden,
   children,
   ...rest
 }) => {
   return (
-    <AccountListItemWrapper {...rest}>
-      <ProfilePicture
+    <AccountListItemWrapper dark={hidden} {...rest}>
+      <AccountAvatar
         src={getNetworkAccountImageUrl({
           accountName,
           accountAddress,
           networkId,
+          backgroundColor: hidden ? "333332" : undefined,
         })}
       />
       <AccountRow>
@@ -134,12 +163,16 @@ export const AccountListItem: FC<IAccountListItem> = ({
               <UpgradeIcon />
               <AccountStatusText>Upgrade</AccountStatusText>
             </NetworkStatusWrapper>
+          ) : connected ? (
+            <ConnectedStatusWrapper>
+              <ConnectedIcon />
+              <AccountStatusText>Connected</AccountStatusText>
+            </ConnectedStatusWrapper>
           ) : (
-            connected && (
-              <ConnectedStatusWrapper>
-                <ConnectedIcon />
-                <AccountStatusText>Connected</AccountStatusText>
-              </ConnectedStatusWrapper>
+            hidden && (
+              <HiddenStatusWrapper>
+                <VisibilityIcon />
+              </HiddenStatusWrapper>
             )
           )}
           {children}

--- a/packages/extension/src/ui/features/accounts/AccountListScreen.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListScreen.tsx
@@ -7,7 +7,11 @@ import { isDeprecated } from "../../../shared/wallet.service"
 import { useAppState } from "../../app.state"
 import { Header } from "../../components/Header"
 import { IconButton } from "../../components/IconButton"
-import { AddIcon, SettingsIcon } from "../../components/Icons/MuiIcons"
+import {
+  AddIcon,
+  SettingsIcon,
+  VisibilityOff,
+} from "../../components/Icons/MuiIcons"
 import { Spinner } from "../../components/Spinner"
 import { routes } from "../../routes"
 import { makeClickable } from "../../services/a11y"
@@ -28,11 +32,16 @@ import {
 } from "./accounts.state"
 import { DeprecatedAccountsWarning } from "./DeprecatedAccountsWarning"
 
-const AccountList = styled.div`
+interface IAccountList {
+  hasHiddenAccounts: boolean
+}
+
+const AccountList = styled.div<IAccountList>`
   display: flex;
   flex-direction: column;
   gap: 24px;
-  padding: 48px 32px;
+  padding: 48px 32px
+    ${({ hasHiddenAccounts }) => (hasHiddenAccounts ? "64px" : "48px")} 32px;
 `
 
 const AccountListWrapper = styled(Container)`
@@ -77,6 +86,52 @@ const DimmingContainer = styled.div`
   bottom: 0;
 `
 
+const Footer = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: ${({ theme }) => theme.bg1};
+  background: linear-gradient(
+    180deg,
+    rgba(16, 16, 16, 0.4) 0%,
+    ${({ theme }) => theme.bg1} 73.72%
+  );
+  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(10px);
+  z-index: 100;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  ${({ theme }) => theme.mediaMinWidth.sm`
+    left: ${theme.margin.extensionInTab};
+    right: ${theme.margin.extensionInTab};
+  `}
+`
+
+const HiddenAccountsButton = styled.button`
+  appearance: none;
+  border: none;
+  background: none;
+  color: ${({ theme }) => theme.text3};
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  transition: color 200ms ease-in-out;
+  &:hover {
+    color: ${({ theme }) => theme.text2};
+  }
+`
+
+const HiddenAccountsButtonIcon = styled.div`
+  font-size: 14px;
+`
+
 export const AccountListScreen: FC = () => {
   const navigate = useNavigate()
   const { switcherNetworkId } = useAppState()
@@ -86,8 +141,6 @@ export const AccountListScreen: FC = () => {
   const { isBackupRequired } = useBackupRequired()
   const [isDeploying, setIsDeploying] = useState(false)
   const [deployFailed, setDeployFailed] = useState(false)
-
-  console.log({ visibleAccounts, hiddenAccounts })
 
   const visibleAccountsList = Object.values(visibleAccounts)
   const hasHiddenAccounts = Object.values(hiddenAccounts).length > 0
@@ -129,7 +182,7 @@ export const AccountListScreen: FC = () => {
         </Header>
       </AccountHeader>
       <H1>Accounts</H1>
-      <AccountList>
+      <AccountList hasHiddenAccounts={hasHiddenAccounts}>
         {isBackupRequired && <RecoveryBanner noMargins />}
         {visibleAccountsList.length === 0 && (
           <Paragraph>
@@ -180,9 +233,16 @@ export const AccountListScreen: FC = () => {
         )}
       </AccountList>
       {hasHiddenAccounts && (
-        <button onClick={() => navigate(routes.accountsHidden())}>
-          Hidden accounts
-        </button>
+        <Footer>
+          <HiddenAccountsButton
+            onClick={() => navigate(routes.accountsHidden())}
+          >
+            <HiddenAccountsButtonIcon>
+              <VisibilityOff fontSize="inherit" />
+            </HiddenAccountsButtonIcon>
+            <div>Hidden accounts</div>
+          </HiddenAccountsButton>
+        </Footer>
       )}
     </AccountListWrapper>
   )

--- a/packages/extension/src/ui/features/accounts/HideOrDeleteAccountConfirmScreen.tsx
+++ b/packages/extension/src/ui/features/accounts/HideOrDeleteAccountConfirmScreen.tsx
@@ -83,7 +83,7 @@ export const HideOrDeleteAccountConfirmScreen: FC<{
       </AddressWrapper>
       <StyledP>
         {mode === "hide"
-          ? "You will be able to unhide the account by recovering your wallet. In the future you will also be able to unhide the account in the settings of the extension."
+          ? "You will be able to unhide the account from the account list screen."
           : "You will not be able to recover this account in the future."}
       </StyledP>
     </ConfirmScreen>

--- a/packages/extension/src/ui/features/accounts/accounts.service.ts
+++ b/packages/extension/src/ui/features/accounts/accounts.service.ts
@@ -45,13 +45,15 @@ export const getNetworkAccountImageUrl = ({
   accountName,
   networkId,
   accountAddress,
+  backgroundColor,
 }: {
   accountName: string
   networkId: string
   accountAddress: string
+  backgroundColor?: string
 }) => {
   const accountIdentifier = `${networkId}::${accountAddress}`
-  const color = getColor(accountIdentifier)
+  const color = backgroundColor || getColor(accountIdentifier)
   return `https://eu.ui-avatars.com/api?name=${accountName}&background=${color}&color=fff`
 }
 

--- a/packages/extension/src/ui/features/accounts/accounts.state.ts
+++ b/packages/extension/src/ui/features/accounts/accounts.state.ts
@@ -36,6 +36,20 @@ export const useAccount = (account?: BaseWalletAccount): Account | undefined =>
     }),
   )
 
+const visibleAccountsSelector = ({ accounts }: Pick<State, "accounts">) =>
+  accounts.filter((account) => !account.hidden)
+
+const hiddenAccountsSelector = ({ accounts }: Pick<State, "accounts">) =>
+  accounts.filter((account) => account.hidden)
+
+export const useVisibleAccounts = () => {
+  return useAccounts(visibleAccountsSelector)
+}
+
+export const useHiddenAccounts = () => {
+  return useAccounts(hiddenAccountsSelector)
+}
+
 export const useSelectedAccount = () =>
   useAccounts(({ accounts, selectedAccount }) =>
     selectedAccount
@@ -48,10 +62,11 @@ export const mapWalletAccountsToAccounts = (
 ): State["accounts"] => {
   return walletAccounts.map(
     (walletAccount) =>
-      new Account(
-        walletAccount.address,
-        walletAccount.network,
-        walletAccount.signer,
-      ),
+      new Account({
+        address: walletAccount.address,
+        network: walletAccount.network,
+        signer: walletAccount.signer,
+        hidden: walletAccount.hidden,
+      }),
   )
 }

--- a/packages/extension/src/ui/features/actions/connectDapp/ConnectDappScreen.tsx
+++ b/packages/extension/src/ui/features/actions/connectDapp/ConnectDappScreen.tsx
@@ -11,7 +11,7 @@ import {
   getAccountName,
   useAccountMetadata,
 } from "../../accounts/accountMetadata.state"
-import { useAccounts } from "../../accounts/accounts.state"
+import { useAccounts, useVisibleAccounts } from "../../accounts/accounts.state"
 import { AccountSelect } from "../../accounts/AccountSelect"
 import { ConfirmPageProps, ConfirmScreen } from "../ConfirmScreen"
 import { ConnectDappAccountListItem } from "./ConnectDappAccountListItem"
@@ -168,7 +168,8 @@ export const ConnectDappScreen: FC<ConnectDappProps> = ({
   host,
   ...rest
 }) => {
-  const { accounts, selectedAccount: initiallySelectedAccount } = useAccounts()
+  const { selectedAccount: initiallySelectedAccount } = useAccounts()
+  const visibleAccounts = useVisibleAccounts()
   const [connectAccountAddress, setConnectAccountAddress] = useState(
     initiallySelectedAccount?.address,
   )
@@ -180,19 +181,16 @@ export const ConnectDappScreen: FC<ConnectDappProps> = ({
 
   const selectedAccount = useMemo(() => {
     if (connectAccountAddress) {
-      const account = accounts.find(
+      const account = visibleAccounts.find(
         ({ address }) => address === connectAccountAddress,
       )
       return account
     }
-  }, [accounts, connectAccountAddress])
+  }, [visibleAccounts, connectAccountAddress])
 
-  const onSelectedAccountChange = useCallback(
-    (accountAddress: string) => {
-      setConnectAccountAddress(accountAddress)
-    },
-    [selectedAccount],
-  )
+  const onSelectedAccountChange = useCallback((accountAddress: string) => {
+    setConnectAccountAddress(accountAddress)
+  }, [])
 
   const onConnect = useCallback(() => {
     selectedAccount && onConnectProp(selectedAccount)
@@ -227,7 +225,7 @@ export const ConnectDappScreen: FC<ConnectDappProps> = ({
       <SmallText>Select the account to connect:</SmallText>
       <SelectContainer>
         <ConnectDappAccountSelect
-          accounts={accounts}
+          accounts={visibleAccounts}
           selectedAccountAddress={connectAccountAddress}
           onSelectedAccountAddressChange={onSelectedAccountChange}
           host={host}

--- a/packages/extension/src/ui/features/recovery/recovery.service.ts
+++ b/packages/extension/src/ui/features/recovery/recovery.service.ts
@@ -20,6 +20,14 @@ interface RecoveryOptions {
   showAccountList?: boolean
 }
 
+// TODO: refactor - currently explicit sync wallet state into UI store, should be reactive
+export const updateAccountsStateFromWallet = async (networkId: string) => {
+  const allAccounts = await getAccounts(true)
+  const walletAccounts = accountsOnNetwork(allAccounts, networkId)
+  const accounts = mapWalletAccountsToAccounts(walletAccounts)
+  useAccounts.setState({ accounts })
+}
+
 export const recover = async ({
   networkId,
   showAccountList,
@@ -28,7 +36,7 @@ export const recover = async ({
     const lastSelectedAccount = await getLastSelectedAccount()
     networkId ??= lastSelectedAccount?.networkId ?? defaultNetwork.id
 
-    const allAccounts = await getAccounts()
+    const allAccounts = await getAccounts(true)
     const walletAccounts = accountsOnNetwork(allAccounts, networkId)
 
     const selectedAccount = walletAccounts.find(

--- a/packages/extension/src/ui/routes.ts
+++ b/packages/extension/src/ui/routes.ts
@@ -76,6 +76,7 @@ export const routes = {
   ),
   upgrade: route("/account/upgrade"),
   accounts: route("/accounts"),
+  accountsHidden: route("/accounts/hidden"),
   newToken: route("/tokens/new"),
   funding: route("/funding"),
   exportPrivateKey: route("/export-private-key"),

--- a/packages/extension/src/ui/services/addressBook.ts
+++ b/packages/extension/src/ui/services/addressBook.ts
@@ -1,8 +1,8 @@
-import { useAccounts } from "../features/accounts/accounts.state"
+import { useVisibleAccounts } from "../features/accounts/accounts.state"
 
 export const useAddressBook = (networkId: string) => {
   // TODO: Implement actual address book
-  const allAccountsOnNetwork = useAccounts().accounts.filter(
+  const allAccountsOnNetwork = useVisibleAccounts().filter(
     (account) => account.networkId === networkId,
   )
 

--- a/packages/extension/src/ui/services/backgroundAccounts.ts
+++ b/packages/extension/src/ui/services/backgroundAccounts.ts
@@ -71,6 +71,20 @@ export const hideAccount = async (address: string, networkId: string) => {
   ])
 }
 
+export const unhideAccount = async (address: string, networkId: string) => {
+  sendMessage({
+    type: "UNHIDE_ACCOUNT",
+    data: { address, networkId },
+  })
+
+  await Promise.race([
+    waitForMessage("UNHIDE_ACCOUNT_RES"),
+    waitForMessage("UNHIDE_ACCOUNT_REJ").then(() => {
+      throw new Error("Rejected")
+    }),
+  ])
+}
+
 export const upgradeAccount = async (data: BaseWalletAccount) => {
   sendMessage({ type: "UPGRADE_ACCOUNT", data })
   try {

--- a/packages/storybook/src/features/accounts/AccountListItem.stories.tsx
+++ b/packages/storybook/src/features/accounts/AccountListItem.stories.tsx
@@ -52,6 +52,12 @@ Connected.args = {
   connected: true,
 }
 
+export const Hidden = Template.bind({})
+Hidden.args = {
+  ...account,
+  hidden: true,
+}
+
 export const Children = Template.bind({})
 Children.args = {
   ...account,


### PR DESCRIPTION
Currently we have a way to hide accounts. They remain hidden forever unless the user resets the extension and inputs their seed phrase again. 

This PR adds an additional screen where a user can see and 'unhide' their hidden accounts.


https://user-images.githubusercontent.com/175607/180749707-1ecd68da-0dea-4469-a059-e20d18db64f5.mov

