### PR TITLE
fix: dollar value of user input

### DIFF
--- a/packages/extension/src/shared/token/price.ts
+++ b/packages/extension/src/shared/token/price.ts
@@ -207,3 +207,47 @@ export const prettifyTokenAmount = ({
   const prettyValueWithSymbol = [prettyValue, symbol].filter(Boolean).join(" ")
   return prettyValueWithSymbol
 }
+
+export interface IConvertTokenAmount {
+  unitAmount?: BigNumberish
+  decimals?: BigNumberish
+}
+
+/**
+ * Convert a unit amount of token into native amount, useful for user input
+ *
+ * @example
+ * ```ts
+ * // Prints '1000000000000000000'
+ * convertTokenUnitAmountWithDecimals({ unitAmount: 1, decimals: 18 }),
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Prints '123'
+ * convertTokenUnitAmountWithDecimals({ unitAmount: 1.23, decimals: 2 }),
+ * ```
+ */
+
+export const convertTokenUnitAmountWithDecimals = ({
+  unitAmount,
+  decimals,
+}: IConvertTokenAmount) => {
+  if (
+    unitAmount === undefined ||
+    !isNumeric(unitAmount) ||
+    decimals === undefined ||
+    !isNumeric(decimals)
+  ) {
+    return
+  }
+  const decimalsNumber = Number(decimals)
+  /** amount to multipy by to take unit amount to token value */
+  const unitMultiplyBy = Math.pow(10, decimalsNumber)
+  /** take unit amount to token amount, enforcing integer */
+  const amount = new CurrencyConversionNumber(unitAmount.toString())
+    .multipliedBy(unitMultiplyBy)
+    .integerValue()
+  /** keep as string to avoid loss of precision elsewhere */
+  return amount.toString()
+}

--- a/packages/extension/src/ui/features/accountTokens/SendTokenScreen.tsx
+++ b/packages/extension/src/ui/features/accountTokens/SendTokenScreen.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components"
 import { Schema, object } from "yup"
 
 import { inputAmountSchema, parseAmount } from "../../../shared/token/amount"
+import { prettifyCurrencyValue } from "../../../shared/token/price"
 import { getFeeToken } from "../../../shared/token/utils"
 import { Button } from "../../components/Button"
 import Column, { ColumnCenter } from "../../components/Column"
@@ -27,7 +28,7 @@ import { useCurrentNetwork } from "../networks/useNetworks"
 import { useYupValidationResolver } from "../settings/useYupValidationResolver"
 import { TokenIcon } from "./TokenIcon"
 import { TokenMenu } from "./TokenMenu"
-import { useTokenBalanceToCurrencyValue } from "./tokenPriceHooks"
+import { useTokenUnitAmountToCurrencyValue } from "./tokenPriceHooks"
 import { formatTokenBalance, toTokenView } from "./tokens.service"
 import { TokenDetailsWithBalance, useTokensWithBalance } from "./tokens.state"
 import { useMaxFeeEstimateForTransfer } from "./useMaxFeeForTransfer"
@@ -167,7 +168,7 @@ export const SendTokenScreen: FC = () => {
   const inputAmount = formValues.amount
 
   const token = tokenDetails.find(({ address }) => address === tokenAddress)
-  const currencyValue = useTokenBalanceToCurrencyValue(token)
+  const currencyValue = useTokenUnitAmountToCurrencyValue(token, inputAmount)
 
   const {
     maxFee,
@@ -284,7 +285,9 @@ export const SendTokenScreen: FC = () => {
                 </InputGroupBefore>
                 <InputGroupAfter>
                   {inputAmount ? (
-                    <CurrencyValueText>{currencyValue}</CurrencyValueText>
+                    <CurrencyValueText>
+                      {prettifyCurrencyValue(currencyValue)}
+                    </CurrencyValueText>
                   ) : (
                     <>
                       <InputTokenSymbol>{token.symbol}</InputTokenSymbol>

--- a/packages/extension/test/tokenPrice.test.ts
+++ b/packages/extension/test/tokenPrice.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest"
 
 import {
   convertTokenAmountToCurrencyValue,
+  convertTokenUnitAmountWithDecimals,
   lookupTokenPriceDetails,
   prettifyCurrencyValue,
   prettifyTokenAmount,
@@ -245,6 +246,44 @@ describe("prettifyTokenAmount()", () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       expect(prettifyTokenAmount({})).toBeNull()
+    })
+  })
+})
+
+describe("convertTokenUnitAmountWithDecimals()", () => {
+  describe("when valid", () => {
+    test("should convert token unit amount", () => {
+      expect(
+        convertTokenUnitAmountWithDecimals({ unitAmount: 0, decimals: 18 }),
+      ).toEqual("0")
+      expect(
+        convertTokenUnitAmountWithDecimals({ unitAmount: 1.23, decimals: 2 }),
+      ).toEqual("123")
+      expect(
+        convertTokenUnitAmountWithDecimals({
+          unitAmount: 1.23456,
+          decimals: 2,
+        }),
+      ).toEqual("123")
+      expect(
+        convertTokenUnitAmountWithDecimals({ unitAmount: 1, decimals: 5 }),
+      ).toEqual("100000")
+      expect(
+        convertTokenUnitAmountWithDecimals({ unitAmount: 1, decimals: 18 }),
+      ).toEqual("1000000000000000000")
+      expect(
+        convertTokenUnitAmountWithDecimals({
+          unitAmount: "1.23456789",
+          decimals: 18,
+        }),
+      ).toEqual("1234567890000000000")
+    })
+  })
+  describe("when invalid", () => {
+    test("should return undefined", () => {
+      expect(
+        convertTokenUnitAmountWithDecimals({ unitAmount: "foo" }),
+      ).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
Adds extra functions that are better suited to taking user input value (e.g. '1.23') for conversion to currency. Open to ideas for better naming :)

Uses these functions to fix an issue in the send screen where the dollar value was not updating.

https://user-images.githubusercontent.com/175607/180770078-61a08c11-52cb-4df5-88e5-427b64e09f6a.mov
