### PR TITLE
fix: dollar value on token detail screen

### DIFF
--- a/packages/extension/src/shared/token/price.ts
+++ b/packages/extension/src/shared/token/price.ts
@@ -174,7 +174,10 @@ export const prettifyCurrencyValue = (
  * Returns a string of token balance with symbol if available e.g.
  */
 
-export const prettifyTokenBalance = (token: TokenDetailsWithBalance) => {
+export const prettifyTokenBalance = (
+  token: TokenDetailsWithBalance,
+  withSymbol = true,
+) => {
   const { balance, decimals, symbol } = token
   if (balance === undefined || decimals === undefined) {
     return null
@@ -182,7 +185,7 @@ export const prettifyTokenBalance = (token: TokenDetailsWithBalance) => {
   return prettifyTokenAmount({
     amount: balance,
     decimals,
-    symbol,
+    symbol: withSymbol ? symbol : "",
   })
 }
 

--- a/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
@@ -2,6 +2,7 @@ import { FC, useMemo } from "react"
 import { Navigate, useNavigate, useParams } from "react-router-dom"
 import styled from "styled-components"
 
+import { prettifyCurrencyValue } from "../../../shared/token/price"
 import { Button } from "../../components/Button"
 import { ColumnCenter } from "../../components/Column"
 import { IconBar } from "../../components/IconBar"
@@ -101,7 +102,9 @@ export const TokenScreen: FC = () => {
               <H3>{symbol}</H3>
             </RowCentered>
             {currencyValue && (
-              <CurrencyValueText>{currencyValue}</CurrencyValueText>
+              <CurrencyValueText>
+                {prettifyCurrencyValue(currencyValue)}
+              </CurrencyValueText>
             )}
           </ColumnCenter>
         </TokenHeader>

--- a/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
@@ -2,7 +2,10 @@ import { FC, useMemo } from "react"
 import { Navigate, useNavigate, useParams } from "react-router-dom"
 import styled from "styled-components"
 
-import { prettifyCurrencyValue } from "../../../shared/token/price"
+import {
+  prettifyCurrencyValue,
+  prettifyTokenBalance,
+} from "../../../shared/token/price"
 import { Button } from "../../components/Button"
 import { ColumnCenter } from "../../components/Column"
 import { IconBar } from "../../components/IconBar"
@@ -80,7 +83,8 @@ export const TokenScreen: FC = () => {
     return <Navigate to={routes.accounts()} />
   }
 
-  const { address, name, symbol, balance, image } = toTokenView(token)
+  const { address, name, symbol, image } = toTokenView(token)
+  const displayBalance = prettifyTokenBalance(token, false)
 
   return (
     <>
@@ -97,7 +101,7 @@ export const TokenScreen: FC = () => {
               style={{ marginTop: "12px" }}
             >
               <H2 style={{ marginBottom: "0px" }} data-testid="tokenBalance">
-                {balance}
+                {displayBalance}
               </H2>
               <H3>{symbol}</H3>
             </RowCentered>


### PR DESCRIPTION
Prettifies the values shown on the token detail screen using the same functions as in the list view.

After

<img width="361" alt="Screenshot 2022-07-25 at 13 00 10" src="https://user-images.githubusercontent.com/175607/180773924-30ade2b0-8044-460c-98f9-cb3dde9fcb09.png">

Before

<img width="361" alt="Screenshot 2022-07-25 at 13 00 25" src="https://user-images.githubusercontent.com/175607/180773950-cfbf9403-4f0a-4b71-8aab-782cdbc65dda.png">

