### PR TITLE
fix: restrict input decimal length to default 16

### DIFF
--- a/packages/extension/src/shared/utils/number.ts
+++ b/packages/extension/src/shared/utils/number.ts
@@ -23,7 +23,7 @@ export const prettifyNumberConfig: Record<string, IPrettifyNumberConfig> = {
   },
   TOKEN: {
     minDecimalPlaces: 4,
-    maxDecimalPlaces: 10,
+    maxDecimalPlaces: 16,
     minDecimalSignificanDigits: 2,
     decimalPlacesWhenZero: 1,
   },

--- a/packages/extension/src/ui/components/InputText.tsx
+++ b/packages/extension/src/ui/components/InputText.tsx
@@ -196,6 +196,20 @@ interface AdditionalControlledInputProps {
   children?: React.ReactNode
 }
 
+export const isAllowedNumericInputValue = (value: string, maxDecimals = 16) => {
+  const numericalRegex = new RegExp(`^[0-9]*.?[0-9]{0,${maxDecimals}}$`)
+  if (value === "") {
+    return true
+  }
+  if (!isNumeric(value)) {
+    return false
+  }
+  if (numericalRegex.test(value)) {
+    return true
+  }
+  return false
+}
+
 export type ControlledInputProps<T extends FieldValues> = InputFieldProps &
   Omit<ControllerProps<T>, "render"> &
   AdditionalControlledInputProps
@@ -224,18 +238,10 @@ export const ControlledInputTextAlt = <T extends FieldValues>({
         inputMode="decimal"
         type="text"
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          const numericalRegex = new RegExp(/^[0-9]*.?[0-9]*$/)
           if (onlyNumeric) {
-            if (e.target.value === "") {
+            if (isAllowedNumericInputValue(e.target.value)) {
               return onValueChange(e)
             }
-
-            return (
-              numericalRegex.test(e.target.value) &&
-              // just being double sure
-              isNumeric(e.target.value) &&
-              onValueChange(e)
-            )
           } else {
             return onValueChange(e)
           }

--- a/packages/extension/src/ui/features/actions/transaction/ERC20TransferTransactionDetails.tsx
+++ b/packages/extension/src/ui/features/actions/transaction/ERC20TransferTransactionDetails.tsx
@@ -5,6 +5,7 @@ import {
   isErc20TransferCall,
   parseErc20TransferCall,
 } from "../../../../shared/call"
+import { prettifyTokenAmount } from "../../../../shared/token/price"
 import { Token } from "../../../../shared/token/type"
 import {
   Field,
@@ -15,7 +16,6 @@ import {
 } from "../../../components/Fields"
 import { formatTruncatedAddress } from "../../../services/addresses"
 import { TokenIcon } from "../../accountTokens/TokenIcon"
-import { formatTokenBalance } from "../../accountTokens/tokens.service"
 import { AccountField } from "./AccountField"
 import { DefaultTransactionDetails } from "./DefaultTransactionDetails"
 import { getKnownWalletAddress } from "./getKnownWalletAddress"
@@ -50,7 +50,13 @@ export const ERC20TransferTransactionDetails: FC<
     address: recipientAddress,
     networkId,
   })
-  const displayAmount = formatTokenBalance(amount, token?.decimals)
+  const displayAmount = token
+    ? prettifyTokenAmount({
+        amount,
+        decimals: token?.decimals,
+        symbol: token?.symbol || "Unknown token",
+      })
+    : amount.toString()
 
   return (
     <FieldGroup>
@@ -58,9 +64,7 @@ export const ERC20TransferTransactionDetails: FC<
         <FieldKey>Send</FieldKey>
         <FieldValue>
           {token && <TokenIcon url={token.image} name={token.name} small />}
-          <LeftPaddedField>
-            {displayAmount} {token?.symbol || "Unknown token"}
-          </LeftPaddedField>
+          <LeftPaddedField>{displayAmount}</LeftPaddedField>
         </FieldValue>
       </Field>
       <Field>

--- a/packages/extension/test/InputText.test.ts
+++ b/packages/extension/test/InputText.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest"
+
+import { isAllowedNumericInputValue } from "../src/ui/components/InputText"
+
+describe("isAllowedNumericInputValue()", () => {
+  describe("when valid", () => {
+    test("should return true", () => {
+      expect(isAllowedNumericInputValue("")).toBeTruthy()
+      expect(isAllowedNumericInputValue("1")).toBeTruthy()
+      expect(isAllowedNumericInputValue("1.")).toBeTruthy()
+      expect(isAllowedNumericInputValue("1.1")).toBeTruthy()
+      expect(isAllowedNumericInputValue("123.123")).toBeTruthy()
+      expect(isAllowedNumericInputValue("123.1234567890123456")).toBeTruthy()
+      expect(isAllowedNumericInputValue("123.123", 3)).toBeTruthy()
+    })
+  })
+  describe("when invalid", () => {
+    test("should return false", () => {
+      expect(isAllowedNumericInputValue("x")).toBeFalsy()
+      expect(isAllowedNumericInputValue("1x")).toBeFalsy()
+      expect(isAllowedNumericInputValue("1.1.")).toBeFalsy()
+      expect(isAllowedNumericInputValue("foo")).toBeFalsy()
+      expect(isAllowedNumericInputValue("123.12345678901234567")).toBeFalsy()
+      expect(isAllowedNumericInputValue("123.1234", 3)).toBeFalsy()
+    })
+  })
+})

--- a/packages/extension/test/tokenPrice.test.ts
+++ b/packages/extension/test/tokenPrice.test.ts
@@ -237,6 +237,12 @@ describe("prettifyTokenAmount()", () => {
           decimals: 18,
         }),
       ).toEqual("123,456,789.0")
+      expect(
+        prettifyTokenAmount({
+          amount: "100",
+          decimals: 18,
+        }),
+      ).toEqual("0.0000000000000001")
     })
   })
   describe("when invalid", () => {


### PR DESCRIPTION
Adds function and tests for checking numeric input, default restricted to max 16 decimals (longer than this causes other libraries e.g. ethers to fail)