### PR TITLE
fix: user can remove non-readonly default network

### DIFF
--- a/packages/extension/src/shared/network/index.ts
+++ b/packages/extension/src/shared/network/index.ts
@@ -1,21 +1,29 @@
 import { mergeArrayStableWith } from "../storage/array"
 import { SelectorFn } from "../storage/types"
 import { assertSchema } from "../utils/schema"
-import { defaultNetworks } from "./defaults"
 import { networkSchema } from "./schema"
 import { networkSelector, networkSelectorByChainId } from "./selectors"
-import { customNetworksStore, equalNetwork } from "./storage"
+import {
+  customNetworksStore,
+  defaultCustomNetworks,
+  defaultReadonlyNetworks,
+  equalNetwork,
+} from "./storage"
 import { Network } from "./type"
 
-export function extendByDefaultNetworks(customNetworks: Network[]) {
-  return mergeArrayStableWith(defaultNetworks, customNetworks, equalNetwork)
+export function extendByDefaultReadonlyNetworks(customNetworks: Network[]) {
+  return mergeArrayStableWith(
+    defaultReadonlyNetworks,
+    customNetworks,
+    equalNetwork,
+  )
 }
 
 export async function getNetworks(
   selector?: SelectorFn<Network>,
 ): Promise<Network[]> {
   const customNetworks = await customNetworksStore.get()
-  const allNetworks = extendByDefaultNetworks(customNetworks)
+  const allNetworks = extendByDefaultReadonlyNetworks(customNetworks)
   if (selector) {
     return allNetworks.filter(selector)
   }
@@ -39,6 +47,12 @@ export const addNetwork = async (network: Network) => {
 
 export const removeNetwork = async (networkId: string) => {
   return customNetworksStore.remove(networkSelector(networkId))
+}
+
+export const restoreDefaultCustomNetworks = async () => {
+  const customNetworks = await customNetworksStore.get()
+  await customNetworksStore.remove(customNetworks)
+  await customNetworksStore.add(defaultCustomNetworks)
 }
 
 export type { Network, NetworkStatus } from "./type"

--- a/packages/extension/src/shared/network/storage.ts
+++ b/packages/extension/src/shared/network/storage.ts
@@ -1,9 +1,21 @@
 import { ArrayStorage } from "../storage"
+import { defaultNetworks } from "./defaults"
 import { Network } from "./type"
 
 export const equalNetwork = (a: Network, b: Network) => a.id === b.id
 
-export const customNetworksStore = new ArrayStorage<Network>([], {
-  namespace: "core:customNetworks",
-  compare: equalNetwork,
-})
+export const defaultCustomNetworks = defaultNetworks.filter(
+  ({ readonly }) => !readonly,
+)
+
+export const defaultReadonlyNetworks = defaultNetworks.filter(
+  ({ readonly }) => !!readonly,
+)
+
+export const customNetworksStore = new ArrayStorage<Network>(
+  defaultCustomNetworks,
+  {
+    namespace: "core:customNetworks",
+    compare: equalNetwork,
+  },
+)

--- a/packages/extension/src/ui/features/networks/useNetworks.ts
+++ b/packages/extension/src/ui/features/networks/useNetworks.ts
@@ -4,7 +4,7 @@ import useSWR from "swr"
 import {
   customNetworksStore,
   defaultNetwork,
-  extendByDefaultNetworks,
+  extendByDefaultReadonlyNetworks,
 } from "../../../shared/network"
 import { useArrayStorage } from "../../../shared/storage/hooks"
 import { useAppState } from "./../../app.state"
@@ -34,9 +34,14 @@ export const useIsMainnet = () => {
 export const useNetworks = () => {
   const customNetworks = useArrayStorage(customNetworksStore)
   return useMemo(
-    () => extendByDefaultNetworks(customNetworks),
+    () => extendByDefaultReadonlyNetworks(customNetworks),
     [customNetworks],
   )
+}
+
+export const useCustomNetworks = () => {
+  const customNetworks = useArrayStorage(customNetworksStore)
+  return customNetworks
 }
 
 export const useNetwork = (networkId: string) => {

--- a/packages/extension/src/ui/features/settings/NetworkSettingsFormScreen.tsx
+++ b/packages/extension/src/ui/features/settings/NetworkSettingsFormScreen.tsx
@@ -1,6 +1,6 @@
 import { Collapse } from "@mui/material"
-import { FC, useCallback, useEffect, useMemo, useState } from "react"
-import { WatchObserver, useForm } from "react-hook-form"
+import { FC, useEffect, useMemo, useState } from "react"
+import { useForm } from "react-hook-form"
 import { useNavigate } from "react-router-dom"
 import styled from "styled-components"
 

--- a/packages/extension/src/ui/features/settings/NetworkSettingsFormScreen.tsx
+++ b/packages/extension/src/ui/features/settings/NetworkSettingsFormScreen.tsx
@@ -1,6 +1,6 @@
 import { Collapse } from "@mui/material"
-import { FC, useEffect, useMemo, useState } from "react"
-import { useForm } from "react-hook-form"
+import { FC, useCallback, useEffect, useMemo, useState } from "react"
+import { WatchObserver, useForm } from "react-hook-form"
 import { useNavigate } from "react-router-dom"
 import styled from "styled-components"
 
@@ -70,7 +70,7 @@ export const NetworkSettingsFormScreen: FC<NetworkSettingsFormScreenProps> = (
 
   useEffect(() => {
     const subscription = watch((value, { name, type }) => {
-      if (type === "change" && name === "name") {
+      if (props.mode === "add" && type === "change" && name === "name") {
         setValue("id", slugify(value.name || ""))
       }
     })

--- a/packages/extension/src/ui/features/settings/NetworkSettingsScreen.tsx
+++ b/packages/extension/src/ui/features/settings/NetworkSettingsScreen.tsx
@@ -1,26 +1,34 @@
+import { isEqual } from "lodash-es"
 import { FC, useMemo } from "react"
 import { Link, useNavigate } from "react-router-dom"
 import styled from "styled-components"
 
 import {
-  customNetworksStore,
-  extendByDefaultNetworks,
   removeNetwork,
+  restoreDefaultCustomNetworks,
 } from "../../../shared/network"
-import { useArrayStorage } from "../../../shared/storage/hooks"
+import { defaultCustomNetworks } from "../../../shared/network/storage"
 import { IconBar } from "../../components/IconBar"
 import { IconButton } from "../../components/IconButton"
-import { AddIcon } from "../../components/Icons/MuiIcons"
+import { AddIcon, RefreshIcon } from "../../components/Icons/MuiIcons"
 import { Spinner } from "../../components/Spinner"
 import { routes } from "../../routes"
 import { H2, P } from "../../theme/Typography"
+import { useCustomNetworks, useNetworks } from "../networks/useNetworks"
 import { DappConnection } from "./DappConnection"
 import { useSelectedNetwork } from "./selectedNetwork.state"
 
-const Wrapper = styled.div`
+interface IWrapper {
+  isDefaultCustomNetworks: boolean
+}
+
+const Wrapper = styled.div<IWrapper>`
   display: flex;
   flex-direction: column;
-  padding: 0 32px 24px 32px;
+  padding: 0 32px
+    ${({ isDefaultCustomNetworks }) =>
+      isDefaultCustomNetworks ? "24px" : "56px"}
+    32px;
   ${H2} {
     margin: 0;
   }
@@ -46,18 +54,66 @@ const List = styled.div`
   }
 `
 
+const Footer = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: ${({ theme }) => theme.bg1};
+  background: linear-gradient(
+    180deg,
+    rgba(16, 16, 16, 0.4) 0%,
+    ${({ theme }) => theme.bg1} 73.72%
+  );
+  box-shadow: 0px 2px 12px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(10px);
+  z-index: 100;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  ${({ theme }) => theme.mediaMinWidth.sm`
+    left: ${theme.margin.extensionInTab};
+    right: ${theme.margin.extensionInTab};
+  `}
+`
+
+const RestoreDefaultsButton = styled.button`
+  appearance: none;
+  border: none;
+  background: none;
+  color: ${({ theme }) => theme.text3};
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  transition: color 200ms ease-in-out;
+  &:hover {
+    color: ${({ theme }) => theme.text2};
+  }
+`
+
+const RestoreDefaultsButtonIcon = styled.div`
+  font-size: 14px;
+`
+
 export const NetworkSettingsScreen: FC = () => {
-  const customNetworks = useArrayStorage(customNetworksStore)
-  const allNetworks = useMemo(() => {
-    return extendByDefaultNetworks(customNetworks)
-  }, [customNetworks])
+  const allNetworks = useNetworks()
   const navigate = useNavigate()
   const [, setSelectedCustomNetwork] = useSelectedNetwork()
+  const customNetworks = useCustomNetworks()
+
+  const isDefaultCustomNetworks = useMemo(() => {
+    return isEqual(customNetworks, defaultCustomNetworks)
+  }, [customNetworks])
 
   return (
     <>
       <IconBar back />
-      <Wrapper>
+      <Wrapper isDefaultCustomNetworks={isDefaultCustomNetworks}>
         <H2>Networks</H2>
         <List>
           {!allNetworks ? (
@@ -87,6 +143,19 @@ export const NetworkSettingsScreen: FC = () => {
             <AddIcon fontSize="large" />
           </IconButtonCenter>
         </Link>
+
+        {!isDefaultCustomNetworks && (
+          <Footer>
+            <RestoreDefaultsButton
+              onClick={async () => await restoreDefaultCustomNetworks()}
+            >
+              <RestoreDefaultsButtonIcon>
+                <RefreshIcon fontSize="inherit" />
+              </RestoreDefaultsButtonIcon>
+              <div>Restore default networks</div>
+            </RestoreDefaultsButton>
+          </Footer>
+        )}
       </Wrapper>
     </>
   )


### PR DESCRIPTION
Adjustments so that default custom networks are non-readonly and can therefore be removed

Add a 'reset' feature so users can restore defaults

We accept that users who upgrade will lose 'localhost' from their custom networks however they can restore it using the 'reset' feature

https://user-images.githubusercontent.com/175607/180965121-0ad70b9f-fd1d-42f7-a8bb-28791cf23e1a.mov


