### PR TITLE
fix: adjust polling behaviour

### DIFF
--- a/packages/extension/src/ui/features/accountTokens/tokenPriceHooks.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokenPriceHooks.ts
@@ -17,7 +17,7 @@ import {
 } from "../../../shared/token/price"
 import { Token } from "../../../shared/token/type"
 import { isNumeric } from "../../../shared/utils/number"
-import { useConditionallyEnabledSWR } from "../../services/swr"
+import { useConditionallyEnabledSWR, withPolling } from "../../services/swr"
 import { useArgentApiFetcher } from "../../services/useArgentApiFetcher"
 import { useBackgroundSettingsValue } from "../../services/useBackgroundSettingsValue"
 import { useIsMainnet } from "../networks/useNetworks"
@@ -37,14 +37,6 @@ export const useCurrencyDisplayEnabled = () => {
   return ARGENT_API_ENABLED && isMainnet && privacyUseArgentServicesEnabled
 }
 
-/** swr config - keep default revalidate behaviour but with refresh and dedepe for 'polling' behaviour */
-export const revalidateThenPoll = (interval: number) => {
-  return {
-    refreshInterval: interval,
-    dedupingInterval: interval /** dedupe multiple requests */,
-  }
-}
-
 /** @returns price and token data which will be cached and refreshed periodically by SWR */
 
 export const usePriceAndTokenDataFromApi = () => {
@@ -54,13 +46,13 @@ export const usePriceAndTokenDataFromApi = () => {
     currencyDisplayEnabled,
     `${ARGENT_API_TOKENS_PRICES_URL}`,
     fetcher,
-    revalidateThenPoll(60 * 1000) /** 60 seconds */,
+    withPolling(60 * 1000) /** 60 seconds */,
   )
   const { data: tokenData } = useConditionallyEnabledSWR<ApiTokenDataResponse>(
     currencyDisplayEnabled,
     `${ARGENT_API_TOKENS_INFO_URL}`,
     fetcher,
-    revalidateThenPoll(5 * 60 * 1000) /** 5 minutes */,
+    withPolling(5 * 60 * 1000) /** 5 minutes */,
   )
   return {
     pricesData,

--- a/packages/extension/src/ui/features/accountTokens/tokenPriceHooks.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokenPriceHooks.ts
@@ -37,6 +37,14 @@ export const useCurrencyDisplayEnabled = () => {
   return ARGENT_API_ENABLED && isMainnet && privacyUseArgentServicesEnabled
 }
 
+/** swr config - keep default revalidate behaviour but with refresh and dedepe for 'polling' behaviour */
+export const revalidateThenPoll = (interval: number) => {
+  return {
+    refreshInterval: interval,
+    dedupingInterval: interval /** dedupe multiple requests */,
+  }
+}
+
 /** @returns price and token data which will be cached and refreshed periodically by SWR */
 
 export const usePriceAndTokenDataFromApi = () => {
@@ -46,17 +54,13 @@ export const usePriceAndTokenDataFromApi = () => {
     currencyDisplayEnabled,
     `${ARGENT_API_TOKENS_PRICES_URL}`,
     fetcher,
-    {
-      refreshInterval: 60 * 1000 /** 60 seconds */,
-    },
+    revalidateThenPoll(60 * 1000) /** 60 seconds */,
   )
   const { data: tokenData } = useConditionallyEnabledSWR<ApiTokenDataResponse>(
     currencyDisplayEnabled,
     `${ARGENT_API_TOKENS_INFO_URL}`,
     fetcher,
-    {
-      refreshInterval: 5 * 60 * 1000 /** 5 minutes */,
-    },
+    revalidateThenPoll(5 * 60 * 1000) /** 5 minutes */,
   )
   return {
     pricesData,

--- a/packages/extension/src/ui/services/swr.ts
+++ b/packages/extension/src/ui/services/swr.ts
@@ -38,6 +38,14 @@ const swrPersistedCache: Cache = {
   },
 }
 
+/** SWR config - keep default behaviour with refresh and dedepe for 'polling' behaviour */
+export const withPolling = (interval: number) => {
+  return {
+    refreshInterval: interval,
+    dedupingInterval: interval /** dedupe multiple requests */,
+  }
+}
+
 /** SWR fetcher used by useConditionallyEnabledSWR when disabled */
 
 const fetcherDisabled: BareFetcher<any> = () => undefined

--- a/packages/extension/src/ui/services/swr.ts
+++ b/packages/extension/src/ui/services/swr.ts
@@ -5,6 +5,7 @@ import useSWR, {
   Key,
   SWRConfiguration,
   unstable_serialize,
+  useSWRConfig,
 } from "swr"
 
 import { reviveJsonBigNumber } from "../../shared/json"
@@ -54,14 +55,18 @@ export function useConditionallyEnabledSWR<Data = any, Error = any>(
   config?: SWRConfiguration<Data, Error, BareFetcher<Data>>,
 ) {
   /** fetcher conditional on enabled */
+  const { cache } = useSWRConfig()
   const result = useSWR<Data, Error>(
-    key,
+    enabled && key,
     enabled ? fetcher : fetcherDisabled,
     config,
   )
-  /** revalidate when enabled changes */
+  /** reset the cache when disabled */
   useEffect(() => {
-    result.mutate()
+    if (!enabled) {
+      result.mutate()
+      cache.delete(key)
+    }
     // dont add result to dependencies to avoid revalidating on every render
   }, [enabled]) // eslint-disable-line react-hooks/exhaustive-deps
   return result

--- a/packages/extension/test/swr.test.tsx
+++ b/packages/extension/test/swr.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react"
-import { useState } from "react"
+import { useCallback, useState } from "react"
+import { SWRConfig } from "swr"
 import { describe, expect, test, vi } from "vitest"
 
 import { useConditionallyEnabledSWR } from "../src/ui/services/swr"
@@ -7,17 +8,21 @@ import { useConditionallyEnabledSWR } from "../src/ui/services/swr"
 describe("swr", () => {
   describe("useConditionallyEnabledSWR()", () => {
     test("should use the fetcher and return data when enabled, set data to undefined when disabled", async () => {
-      const fetcher = vi.fn(() => "foo")
+      const fetcher = vi.fn((value: string) => value)
+      const cache = new Map()
 
       function Component() {
+        const [value, setValue] = useState("foo")
         const [enabled, setEnabled] = useState(true)
+        const valueFetcher = useCallback(() => fetcher(value), [value])
         const { data } = useConditionallyEnabledSWR<string>(
           enabled,
           "test-key",
-          fetcher,
+          valueFetcher,
         )
         return (
           <div>
+            <p>value:{value}</p>
             <p>data:{data === undefined ? "undefined" : data}</p>
             <button
               onClick={() => {
@@ -26,14 +31,49 @@ describe("swr", () => {
             >
               toggle
             </button>
+            <button
+              onClick={() => {
+                setValue("bar")
+              }}
+            >
+              update
+            </button>
           </div>
         )
       }
 
-      render(<Component />)
+      render(
+        <SWRConfig value={{ provider: () => cache }}>
+          <Component />
+        </SWRConfig>,
+      )
       await screen.findByText("data:foo")
-      // Initially called 2 times at this point
+      expect(fetcher).toHaveBeenCalledTimes(1)
+      expect(cache.get("test-key")).toEqual("foo")
+
+      // Change to disabled
+      fireEvent.click(screen.getByText("toggle"))
+
+      // Should reset the data and not call fetcher() again
+      await screen.findByText("data:undefined")
+      expect(fetcher).toHaveBeenCalledTimes(1)
+
+      // Cache should be deleted
+      expect(cache.get("test-key")).toBeUndefined()
+
+      // Change to enabled
+      fireEvent.click(screen.getByText("toggle"))
+
+      // Should fetch the data and call fetcher() again
+      await screen.findByText("data:foo")
       expect(fetcher).toHaveBeenCalledTimes(2)
+
+      // Cache should be populated
+      expect(cache.get("test-key")).toEqual("foo")
+
+      // Update the returned value
+      fireEvent.click(screen.getByText("update"))
+      await screen.findByText("value:bar")
 
       // Change to disabled
       fireEvent.click(screen.getByText("toggle"))
@@ -42,12 +82,18 @@ describe("swr", () => {
       await screen.findByText("data:undefined")
       expect(fetcher).toHaveBeenCalledTimes(2)
 
+      // Cache should be deleted
+      expect(cache.get("test-key")).toBeUndefined()
+
       // Change to enabled
       fireEvent.click(screen.getByText("toggle"))
 
-      // Should fetch the data and call fetcher() again
-      await screen.findByText("data:foo")
+      // Should fetch the updated data and call fetcher() again
+      await screen.findByText("data:bar")
       expect(fetcher).toHaveBeenCalledTimes(3)
+
+      // Cache should be populated
+      expect(cache.get("test-key")).toEqual("bar")
     })
   })
 })


### PR DESCRIPTION
Adds adjustments and tests to the 'polling' behaviour for token and price endpoints.

New behaviour
* Default revalidate on mount (otherwise you may never see fresh prices)
* Dedupe requests to poll interval (otherwise 'mount' behaviour above causes multiple requests)

Previous behaviour
* Lack of 'dedupe' could cause multiple requests when remounting components, e.g. switching accounts