### PR TITLE
fix: don't show tokens until account is deployed

### DIFF
--- a/packages/extension/src/ui/features/accountTokens/AccountTokens.tsx
+++ b/packages/extension/src/ui/features/accountTokens/AccountTokens.tsx
@@ -127,7 +127,7 @@ export const AccountTokens: FC<AccountTokensProps> = ({ account }) => {
   }, [account])
 
   const tokenListVariant = currencyDisplayEnabled ? "default" : "no-currency"
-
+  const tokensEnabled = status.code !== "DEPLOYING" && status.code !== "ERROR"
   return (
     <Container data-testid="account-tokens">
       <AccountSubHeader
@@ -153,41 +153,43 @@ export const AccountTokens: FC<AccountTokensProps> = ({ account }) => {
       {showNoBalanceForUpgrade && <UpgradeBanner canNotPay />}
       <PendingTransactionsContainer account={account} />
       {/** TODO: remove this extra error boundary once TokenList issues are settled */}
-      <ErrorBoundary
-        fallback={
-          <ErrorBoundaryFallbackWithCopyError
-            message={"Sorry, an error occurred fetching tokens"}
-          />
-        }
-      >
-        {error ? (
-          <ErrorBoundaryFallbackWithCopyError
-            error={error}
-            message={"Sorry, an error occurred fetching tokens"}
-          />
-        ) : (
-          <>
-            <TokenList
-              showTitle={showPendingTransactions}
-              isValidating={isValidating}
-              tokenList={tokenDetails}
-              variant={tokenListVariant}
+      {tokensEnabled && (
+        <ErrorBoundary
+          fallback={
+            <ErrorBoundaryFallbackWithCopyError
+              message={"Sorry, an error occurred fetching tokens"}
             />
-            {tokenDetailsIsInitialising ? (
-              <Spinner size={64} style={{ marginTop: 40 }} />
-            ) : (
-              <TokenWrapper
-                {...makeClickable(() => navigate(routes.newToken()))}
-              >
-                <AddTokenIconButton size={40}>
-                  <AddIcon />
-                </AddTokenIconButton>
-                <TokenTitle>Add token</TokenTitle>
-              </TokenWrapper>
-            )}
-          </>
-        )}
-      </ErrorBoundary>
+          }
+        >
+          {error ? (
+            <ErrorBoundaryFallbackWithCopyError
+              error={error}
+              message={"Sorry, an error occurred fetching tokens"}
+            />
+          ) : (
+            <>
+              <TokenList
+                showTitle={showPendingTransactions}
+                isValidating={isValidating}
+                tokenList={tokenDetails}
+                variant={tokenListVariant}
+              />
+              {tokenDetailsIsInitialising ? (
+                <Spinner size={64} style={{ marginTop: 40 }} />
+              ) : (
+                <TokenWrapper
+                  {...makeClickable(() => navigate(routes.newToken()))}
+                >
+                  <AddTokenIconButton size={40}>
+                    <AddIcon />
+                  </AddTokenIconButton>
+                  <TokenTitle>Add token</TokenTitle>
+                </TokenWrapper>
+              )}
+            </>
+          )}
+        </ErrorBoundary>
+      )}
     </Container>
   )
 }

--- a/packages/extension/src/ui/features/accountTokens/tokens.state.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.state.ts
@@ -84,14 +84,18 @@ export const useTokensWithBalance = (
     {
       refreshInterval: 30000,
       shouldRetryOnError: (error) => {
-        const suppressError = SUPPRESS_ERROR_STATUS.includes(error?.status)
+        const errorCode = error?.status || error?.errorCode
+        const suppressError =
+          errorCode && SUPPRESS_ERROR_STATUS.includes(errorCode)
         return suppressError
       },
     },
   )
 
   const error = useMemo(() => {
-    if (!SUPPRESS_ERROR_STATUS.includes(maybeSuppressError?.status)) {
+    const errorCode =
+      maybeSuppressError?.status || maybeSuppressError?.errorCode
+    if (!SUPPRESS_ERROR_STATUS.includes(errorCode)) {
       return maybeSuppressError
     }
   }, [maybeSuppressError])


### PR DESCRIPTION
* don’t show the token list until the account is deployed
* update the check for 429 error - was only checking the error key `status` but looks like it comes through as `errorCode` here