### PR TITLE
feat: pending transactions badge

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -29,6 +29,7 @@ import { handlePreAuthorizationMessage } from "./preAuthorizationMessaging"
 import { handleRecoveryMessage } from "./recoveryMessaging"
 import { handleSessionMessage } from "./sessionMessaging"
 import { handleTokenMessaging } from "./tokenMessaging"
+import { initBadgeText } from "./transactions/badgeText"
 import { transactionTracker } from "./transactions/tracking"
 import { handleTransactionMessage } from "./transactions/transactionMessaging"
 import { Wallet, sessionStore, walletStore } from "./wallet"
@@ -65,6 +66,10 @@ browser.alarms.onAlarm.addListener(async (alarm) => {
     }
   }
 })
+
+// badge shown on extension icon
+
+initBadgeText()
 
 // runs on startup
 

--- a/packages/extension/src/background/transactions/badgeText.ts
+++ b/packages/extension/src/background/transactions/badgeText.ts
@@ -1,0 +1,48 @@
+import { memoize } from "lodash-es"
+
+import {
+  hideNotificationBadge,
+  showNotificationBadge,
+} from "../../shared/browser/badgeText"
+import { Transaction } from "../../shared/transactions"
+import { BaseWalletAccount } from "../../shared/wallet.model"
+import { accountsEqual } from "../../shared/wallet.service"
+import { walletStore } from "../wallet"
+import { transactionsStore } from "./store"
+
+// selects transactions that are pending and match the provided account
+
+export const pendingAccountTransactionsSelector = memoize(
+  (account: BaseWalletAccount) => (transaction: Transaction) =>
+    transaction.status === "RECEIVED" &&
+    accountsEqual(account, transaction.account),
+)
+
+// show count of pending transactions for current account
+
+export const updateBadgeText = async () => {
+  const selectedWalletAccount = await walletStore.get("selected")
+  if (!selectedWalletAccount) {
+    hideNotificationBadge()
+    return
+  }
+  const selector = pendingAccountTransactionsSelector(selectedWalletAccount)
+  const pendingAccountTransactions = await transactionsStore.get(selector)
+  if (pendingAccountTransactions.length) {
+    showNotificationBadge(pendingAccountTransactions.length)
+  } else {
+    hideNotificationBadge()
+  }
+}
+
+export const initBadgeText = () => {
+  walletStore.subscribe("selected", () => {
+    updateBadgeText()
+  })
+
+  transactionsStore.subscribe(() => {
+    updateBadgeText()
+  })
+
+  updateBadgeText()
+}

--- a/packages/extension/src/shared/actionQueue/store.ts
+++ b/packages/extension/src/shared/actionQueue/store.ts
@@ -1,5 +1,3 @@
-import browser from "webextension-polyfill"
-
 import { ArrayStorage } from "../storage"
 import { ExtensionActionItem } from "./types"
 
@@ -11,15 +9,3 @@ export const globalActionQueueStore = new ArrayStorage<ExtensionActionItem>(
     compare: (a, b) => a.meta.hash === b.meta.hash,
   },
 )
-
-const showNotificationBadge = (actions: ExtensionActionItem[]) => {
-  browser.action.setBadgeText({
-    text: `${actions.length || ""}`, // 0 should not show a badge
-  })
-
-  browser.action.setBadgeBackgroundColor({ color: "#29C5FF" })
-}
-
-globalActionQueueStore.subscribe((all) => {
-  showNotificationBadge(all)
-})

--- a/packages/extension/src/shared/browser/badgeText.ts
+++ b/packages/extension/src/shared/browser/badgeText.ts
@@ -1,10 +1,14 @@
 import browser from "webextension-polyfill"
 
+/** browserAction is v2 API, action is v3 */
+
+const action = browser.browserAction || browser.action
+
 export const showNotificationBadge = (text: string | number) => {
-  browser.browserAction.setBadgeText({
+  action.setBadgeText({
     text: String(text),
   })
-  browser.browserAction.setBadgeBackgroundColor({ color: "#29C5FF" })
+  action.setBadgeBackgroundColor({ color: "#29C5FF" })
 }
 
 export const hideNotificationBadge = () => {

--- a/packages/extension/src/shared/browser/badgeText.ts
+++ b/packages/extension/src/shared/browser/badgeText.ts
@@ -1,0 +1,12 @@
+import browser from "webextension-polyfill"
+
+export const showNotificationBadge = (text: string | number) => {
+  browser.browserAction.setBadgeText({
+    text: String(text),
+  })
+  browser.browserAction.setBadgeBackgroundColor({ color: "#29C5FF" })
+}
+
+export const hideNotificationBadge = () => {
+  showNotificationBadge("")
+}

--- a/packages/extension/src/ui/features/accounts/AccountContainer.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountContainer.tsx
@@ -10,11 +10,12 @@ import {
 } from "../../components/Icons/MuiIcons"
 import { routes } from "../../routes"
 import { NetworkSwitcher } from "../networks/NetworkSwitcher"
-import { AccountFooter, FooterTab } from "./AccountFooter"
+import { AccountFooter, FooterTab, FooterTabBadge } from "./AccountFooter"
 import { AccountHeader } from "./AccountHeader"
 import { getAccountName, useAccountMetadata } from "./accountMetadata.state"
 import { getAccountImageUrl } from "./accounts.service"
 import { useSelectedAccount } from "./accounts.state"
+import { useAccountTransactions } from "./accountTransactions.state"
 import { ProfilePicture } from "./ProfilePicture"
 
 export const Container = styled.div<{
@@ -47,6 +48,8 @@ export const AccountContainer: FC<AccountScreenContentProps> = ({
 }) => {
   const { accountNames } = useAccountMetadata()
   const account = useSelectedAccount()
+  const { pendingTransactions } = useAccountTransactions(account)
+  const hasPendingTransactions = !!pendingTransactions.length
 
   if (!account) {
     return <></>
@@ -82,6 +85,9 @@ export const AccountContainer: FC<AccountScreenContentProps> = ({
         <FooterTab to={routes.accountActivity()}>
           <FormatListBulletedIcon />
           <span>Activity</span>
+          {hasPendingTransactions && (
+            <FooterTabBadge>{pendingTransactions.length}</FooterTabBadge>
+          )}
         </FooterTab>
       </AccountFooter>
     </Container>

--- a/packages/extension/src/ui/features/accounts/AccountFooter.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountFooter.tsx
@@ -22,6 +22,7 @@ export const AccountFooter = styled.div`
 `
 
 export const FooterTab = styled(Link)`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -44,4 +45,24 @@ export const FooterTab = styled(Link)`
     outline: 0;
     background: rgba(255, 255, 255, 0.05);
   }
+`
+
+export const FooterTabBadge = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  position: absolute;
+  left: 50%;
+  top: 4px;
+  width: 16px;
+  height: 16px;
+  margin-left: 12px;
+  padding: 6px;
+  border-radius: 500px;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 600;
+  color: ${({ theme }) => theme.white};
+  background-color: ${({ theme }) => theme.blue1};
 `


### PR DESCRIPTION
This shows the count of pending transactions of the currently selected account with a new badge in the 'Activity' tab and changes to the count logic in the extension icon (which previously showed a count of pending actions). The extension icon will update in the background.