### PR TITLE
update session with RequestSession

### DIFF
--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -44,7 +44,7 @@ Next you need to come up with the permissions you would like for your session. Y
 This example session will allow the dapp to execute an example endpoint on an example contract without asking the user to approve the transaction again. After signing the session the dapp can execute all transactions listed in `policies` whenever it wants and as many times as it wants.
 
 ```typescript
-import { Signer, ec } from "@argent/x-sessions"
+import { Signer, ec } from "starknet"
 
 // gets signer with random private key you need to store if you want to reuse the session
 const sessionSigner = new Signer()

--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -26,7 +26,7 @@ interface Policy {
   selector: string
 }
 
-interface Session {
+interface RequestSession {
   key: string
   expires: number
   policies: Policy[]
@@ -49,7 +49,7 @@ import { Signer, ec } from "starknet"
 // gets signer with random private key you need to store if you want to reuse the session
 const sessionSigner = new Signer()
 
-const session: Session = {
+const requestSession: RequestSession = {
   key: await sessionSigner.getPublicKey(),
   expires: Math.floor((Date.now() + 1000 * 60 * 60 * 24) / 1000), // 1 day in seconds
   policies: [
@@ -67,7 +67,7 @@ Now you can sign the session with the account you have. Depending on how your ac
 import { session } from "starknet"
 
 // calls account.signMessage internally
-const signedSession = await session.createSession(session, account)
+const signedSession = await session.createSession(requestSession, account)
 ```
 
 ### Using established sessions

--- a/packages/sessions/README.md
+++ b/packages/sessions/README.md
@@ -44,7 +44,7 @@ Next you need to come up with the permissions you would like for your session. Y
 This example session will allow the dapp to execute an example endpoint on an example contract without asking the user to approve the transaction again. After signing the session the dapp can execute all transactions listed in `policies` whenever it wants and as many times as it wants.
 
 ```typescript
-import { Signer, ec } from "starknet"
+import { Signer, ec } from "@argent/x-sessions"
 
 // gets signer with random private key you need to store if you want to reuse the session
 const sessionSigner = new Signer()
@@ -64,10 +64,10 @@ const requestSession: RequestSession = {
 Now you can sign the session with the account you have. Depending on how your account works, the user may get asked to sign a message
 
 ```typescript
-import { session } from "starknet"
+import { createSession } from "@argent/x-sessions"
 
 // calls account.signMessage internally
-const signedSession = await session.createSession(requestSession, account)
+const signedSession = await createSession(requestSession, account)
 ```
 
 ### Using established sessions
@@ -75,7 +75,7 @@ const signedSession = await session.createSession(requestSession, account)
 With your signed session you can now use it with your dapp to do transactions without the user having to approve again.
 
 ```typescript
-import { SessionAccount } from "starknet"
+import { SessionAccount } from "@argent/x-sessions"
 
 const sessionAccount = new SessionAccount(
   account,


### PR DESCRIPTION
There should actually 2 be differents object:
- `Signer` and `ec` come from starknet.js and provides the command create a session key and sign transactions
- `sessionRequest: SessionRequest` and `createSession` are defined in @argent/x-sessions and are used to generate the signedSession