### PR TITLE
fix: improve display of long account name in list

### DIFF
--- a/packages/extension/src/ui/features/accounts/AccountListItem.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListItem.tsx
@@ -80,6 +80,12 @@ const AccountAvatar = styled.img`
 const AccountColumn = styled.div`
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+`
+
+const AccountColumnAccessory = styled.div`
+  display: flex;
+  flex-direction: column;
 `
 
 const AccountRow = styled.div`
@@ -87,6 +93,7 @@ const AccountRow = styled.div`
   flex-grow: 1;
   align-items: center;
   justify-content: space-between;
+  overflow: hidden;
 `
 
 const AccountStatusText = styled.p`
@@ -101,6 +108,9 @@ const AccountName = styled.h1`
   font-size: 18px;
   line-height: 18px;
   margin: 0 0 5px 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `
 
 const AccountAddress = styled.div`
@@ -204,7 +214,7 @@ export const AccountListItem: FC<IAccountListItem> = ({
             </AccountAddress>
           )}
         </AccountColumn>
-        <AccountColumn>
+        <AccountColumnAccessory>
           {accountType === "argent-plugin" && (
             <PluginTextContainer>Plugin</PluginTextContainer>
           )}
@@ -231,7 +241,7 @@ export const AccountListItem: FC<IAccountListItem> = ({
             )
           )}
           {children}
-        </AccountColumn>
+        </AccountColumnAccessory>
       </AccountRow>
     </AccountListItemWrapper>
   )


### PR DESCRIPTION
Update the account list styling to cause long names to truncate

<img width="340" alt="Screenshot 2022-09-07 at 11 04 24" src="https://user-images.githubusercontent.com/175607/188851854-185ee507-56d8-4296-b506-a4e5d711f92a.png">

<img width="340" alt="Screenshot 2022-09-07 at 11 04 06" src="https://user-images.githubusercontent.com/175607/188851844-42b060c0-4830-4bc5-b2e2-84e4fe913c00.png">

<img width="340" alt="Screenshot 2022-09-07 at 11 04 13" src="https://user-images.githubusercontent.com/175607/188851849-91400ee6-e291-404d-b2ce-5399965104d2.png">

<img width="340" alt="Screenshot 2022-09-07 at 11 04 18" src="https://user-images.githubusercontent.com/175607/188851851-bbdfd475-7ee8-4e0a-ace3-d824b47dd138.png">
