### PR TITLE
export the Policy interface

### DIFF
--- a/packages/sessions/src/utils.ts
+++ b/packages/sessions/src/utils.ts
@@ -9,7 +9,7 @@ import {
   typedData,
 } from "starknet"
 
-interface Policy {
+export interface Policy {
   contractAddress: string
   selector: string
 }


### PR DESCRIPTION
It could be beneficial you export `Policy` especially because (1) you reference it in the doc and export requestSession and (2) you might want to change it and it would help if I do not redefine it. Obviously this configuration might also be on purpose to force using `preparePolicy`