### PR TITLE
fix: notification trigger

### DIFF
--- a/packages/extension/src/background/miscellaneousMessaging.ts
+++ b/packages/extension/src/background/miscellaneousMessaging.ts
@@ -15,10 +15,14 @@ export const handleMiscellaneousMessage: HandleMessage<
     }
 
     case "RESET_ALL": {
-      browser.storage.local.clear()
-      browser.storage.sync.clear()
-      browser.storage.managed.clear()
-      browser.storage.session.clear()
+      try {
+        browser.storage.local.clear()
+        browser.storage.sync.clear()
+        browser.storage.managed.clear()
+        browser.storage.session.clear()
+      } catch {
+        // Ignore browser.storage.session error "This is a read-only store"
+      }
       return sendToTabAndUi({ type: "DISCONNECT_ACCOUNT" })
     }
 

--- a/packages/extension/src/background/notification.ts
+++ b/packages/extension/src/background/notification.ts
@@ -1,7 +1,22 @@
 import { Status } from "starknet"
 import browser from "webextension-polyfill"
 
+import { ArrayStorage } from "../shared/storage"
 import { TransactionMeta } from "../shared/transactions"
+
+const notificationsStorage = new ArrayStorage<string>(
+  [],
+  "core:notifications:seenTransactions",
+)
+
+export async function hasShownNotification(hash: string) {
+  const [hit] = await notificationsStorage.get((h) => h === hash)
+  return !!hit
+}
+
+export async function addToAlreadyShown(hash: string) {
+  await notificationsStorage.push(hash)
+}
 
 export async function sentTransactionNotification(
   hash: string,

--- a/packages/extension/src/background/notification.ts
+++ b/packages/extension/src/background/notification.ts
@@ -1,22 +1,7 @@
 import { Status } from "starknet"
 import browser from "webextension-polyfill"
 
-import { ArrayStorage } from "../shared/storage"
 import { TransactionMeta } from "../shared/transactions"
-
-const notificationsStorage = new ArrayStorage<string>(
-  [],
-  "core:notifications:seenTransactions",
-)
-
-export async function hasShownNotification(hash: string) {
-  const [hit] = await notificationsStorage.get((h) => h === hash)
-  return !!hit
-}
-
-export async function addToAlreadyShown(hash: string) {
-  await notificationsStorage.push(hash)
-}
 
 export async function sentTransactionNotification(
   hash: string,

--- a/packages/extension/src/background/transactions/onupdate/index.ts
+++ b/packages/extension/src/background/transactions/onupdate/index.ts
@@ -1,12 +1,29 @@
+import { checkResetStoredNonce } from "./nonce"
 import { notifyAboutCompletedTransactions } from "./notifications"
 import { TransactionUpdateListener } from "./type"
 import { handleUpgradeTransaction } from "./upgrade"
 
-const updateHandlers: TransactionUpdateListener[] = [
-  notifyAboutCompletedTransactions,
+const addedOrUpdatedHandlers: TransactionUpdateListener[] = [
   handleUpgradeTransaction,
+  checkResetStoredNonce,
 ]
 
-export const runUpdateHandlers: TransactionUpdateListener = async (updates) => {
-  await Promise.allSettled(updateHandlers.map((handler) => handler(updates)))
+export const runAddedOrUpdatedHandlers: TransactionUpdateListener = async (
+  updates,
+) => {
+  await Promise.allSettled(
+    addedOrUpdatedHandlers.map((handler) => handler(updates)),
+  )
+}
+
+const changedStatusHandlers: TransactionUpdateListener[] = [
+  notifyAboutCompletedTransactions,
+]
+
+export const runChangedStatusHandlers: TransactionUpdateListener = async (
+  updates,
+) => {
+  await Promise.allSettled(
+    changedStatusHandlers.map((handler) => handler(updates)),
+  )
 }

--- a/packages/extension/src/background/transactions/onupdate/nonce.ts
+++ b/packages/extension/src/background/transactions/onupdate/nonce.ts
@@ -1,0 +1,13 @@
+import { resetStoredNonce } from "../../nonce"
+import { TransactionUpdateListener } from "./type"
+
+export const checkResetStoredNonce: TransactionUpdateListener = async (
+  transactions,
+) => {
+  for (const transaction of transactions) {
+    // on error remove stored (increased) nonce
+    if (transaction.account && transaction.status === "REJECTED") {
+      await resetStoredNonce(transaction.account)
+    }
+  }
+}

--- a/packages/extension/src/background/transactions/onupdate/notifications.ts
+++ b/packages/extension/src/background/transactions/onupdate/notifications.ts
@@ -1,29 +1,15 @@
 import { SUCCESS_STATUSES } from "../../../shared/transactions"
-import { resetStoredNonce } from "../../nonce"
-import {
-  addToAlreadyShown,
-  hasShownNotification,
-  sentTransactionNotification,
-} from "../../notification"
+import { sentTransactionNotification } from "../../notification"
 import { TransactionUpdateListener } from "./type"
 
 export const notifyAboutCompletedTransactions: TransactionUpdateListener =
   async (transactions) => {
     for (const transaction of transactions) {
       const { hash, status, meta, account } = transaction
-      if (
-        (SUCCESS_STATUSES.includes(status) || status === "REJECTED") &&
-        !(await hasShownNotification(hash))
-      ) {
-        addToAlreadyShown(hash)
-
+      if (SUCCESS_STATUSES.includes(status) || status === "REJECTED") {
         if (!account.hidden) {
           sentTransactionNotification(hash, status, meta)
         }
-      }
-      // on error remove stored (increased) nonce
-      if (transaction.account && status === "REJECTED") {
-        await resetStoredNonce(transaction.account)
       }
     }
   }

--- a/packages/extension/src/background/transactions/onupdate/notifications.ts
+++ b/packages/extension/src/background/transactions/onupdate/notifications.ts
@@ -1,12 +1,21 @@
 import { SUCCESS_STATUSES } from "../../../shared/transactions"
-import { sentTransactionNotification } from "../../notification"
+import {
+  addToAlreadyShown,
+  hasShownNotification,
+  sentTransactionNotification,
+} from "../../notification"
 import { TransactionUpdateListener } from "./type"
 
 export const notifyAboutCompletedTransactions: TransactionUpdateListener =
   async (transactions) => {
     for (const transaction of transactions) {
       const { hash, status, meta, account } = transaction
-      if (SUCCESS_STATUSES.includes(status) || status === "REJECTED") {
+      if (
+        (SUCCESS_STATUSES.includes(status) || status === "REJECTED") &&
+        !(await hasShownNotification(hash))
+      ) {
+        addToAlreadyShown(hash)
+
         if (!account.hidden) {
           sentTransactionNotification(hash, status, meta)
         }


### PR DESCRIPTION
Triggers notification on known transaction status change instead of load. This fixes an issue where restoring a wallet would trigger a notification for every single transaction.