### PR TITLE
fix: address field crash

### DIFF
--- a/packages/extension/src/ui/components/InputText.tsx
+++ b/packages/extension/src/ui/components/InputText.tsx
@@ -193,6 +193,7 @@ export const ControlledInputText = styled(
 
 interface AdditionalControlledInputProps {
   onlyNumeric?: boolean
+  onlyAddressHex?: boolean
   children?: React.ReactNode
 }
 
@@ -210,6 +211,17 @@ export const isAllowedNumericInputValue = (value: string, maxDecimals = 16) => {
   return false
 }
 
+export const isAllowedAddressHexInputValue = (value: string) => {
+  const hexRegex = /^(|0|0x([a-f0-9A-F]+)?)$/
+  if (value === "") {
+    return true
+  }
+  if (hexRegex.test(value)) {
+    return true
+  }
+  return false
+}
+
 export type ControlledInputProps<T extends FieldValues> = InputFieldProps &
   Omit<ControllerProps<T>, "render"> &
   AdditionalControlledInputProps
@@ -220,6 +232,7 @@ export const ControlledInputTextAlt = <T extends FieldValues>({
   defaultValue,
   rules,
   onlyNumeric,
+  onlyAddressHex,
   children,
   ...props
 }: ControlledInputProps<T>) => (
@@ -240,6 +253,10 @@ export const ControlledInputTextAlt = <T extends FieldValues>({
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           if (onlyNumeric) {
             if (isAllowedNumericInputValue(e.target.value)) {
+              return onValueChange(e)
+            }
+          } else if (onlyAddressHex) {
+            if (isAllowedAddressHexInputValue(e.target.value)) {
               return onValueChange(e)
             }
           } else {
@@ -322,6 +339,7 @@ export const ControlledTextAreaAlt = <T extends FieldValues>({
   defaultValue,
   rules,
   onlyNumeric,
+  onlyAddressHex,
   maxRows,
   children,
   onChange,
@@ -341,6 +359,11 @@ export const ControlledTextAreaAlt = <T extends FieldValues>({
         onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
           if (onlyNumeric) {
             if (isAllowedNumericInputValue(e.target.value)) {
+              onValueChange(e)
+              return isFunction(onChange) && onChange(e)
+            }
+          } else if (onlyAddressHex) {
+            if (isAllowedAddressHexInputValue(e.target.value)) {
               onValueChange(e)
               return isFunction(onChange) && onChange(e)
             }

--- a/packages/extension/src/ui/features/accountNfts/SendNftScreen.tsx
+++ b/packages/extension/src/ui/features/accountNfts/SendNftScreen.tsx
@@ -266,6 +266,7 @@ export const SendNftScreen: FC = () => {
                       paddingRight: "50px",
                       borderRadius: addressBookOpen ? "8px 8px 0 0" : "8px",
                     }}
+                    onlyAddressHex
                     onChange={(e: any) => {
                       if (validateStarknetAddress(e.target.value)) {
                         const account = addressBook.contacts.find((c) =>

--- a/packages/extension/src/ui/features/accountTokens/SendTokenScreen.tsx
+++ b/packages/extension/src/ui/features/accountTokens/SendTokenScreen.tsx
@@ -470,6 +470,7 @@ export const SendTokenScreen: FC = () => {
                       paddingRight: "50px",
                       borderRadius: addressBookOpen ? "8px 8px 0 0" : "8px",
                     }}
+                    onlyAddressHex
                     onChange={(e) => {
                       if (validateStarknetAddress(e.target.value)) {
                         const account = addressBook.contacts.find((c) =>

--- a/packages/extension/src/ui/features/settings/AddressbookAddOrEditScreen.tsx
+++ b/packages/extension/src/ui/features/settings/AddressbookAddOrEditScreen.tsx
@@ -240,6 +240,7 @@ export const AddressbookAddOrEditScreen: FC<AddressbookAddOrEditProps> = ({
               minRows={3}
               maxRows={3}
               spellCheck={false}
+              onlyAddressHex
             />
             {errors.address && (
               <FormErrorAlt>{errors.address.message}</FormErrorAlt>

--- a/packages/extension/src/ui/services/addresses.ts
+++ b/packages/extension/src/ui/services/addresses.ts
@@ -1,3 +1,4 @@
+import { isHexString } from "ethers/lib/utils"
 import {
   constants,
   getChecksumAddress,
@@ -69,5 +70,11 @@ export const addressSchema = yup
 export const isValidAddress = (address: string) =>
   addressSchema.isValidSync(address)
 
-export const isEqualAddress = (a: string, b: string) =>
-  number.hexToDecimalString(a) === number.hexToDecimalString(b)
+export const isEqualAddress = (a: string, b: string) => {
+  try {
+    return number.hexToDecimalString(a) === number.hexToDecimalString(b)
+  } catch {
+    // ignore parsing error
+  }
+  return false
+}

--- a/packages/extension/test/InputText.test.ts
+++ b/packages/extension/test/InputText.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest"
 
-import { isAllowedNumericInputValue } from "../src/ui/components/InputText"
+import {
+  isAllowedAddressHexInputValue,
+  isAllowedNumericInputValue,
+} from "../src/ui/components/InputText"
 
 describe("isAllowedNumericInputValue()", () => {
   describe("when valid", () => {
@@ -22,6 +25,29 @@ describe("isAllowedNumericInputValue()", () => {
       expect(isAllowedNumericInputValue("foo")).toBeFalsy()
       expect(isAllowedNumericInputValue("123.12345678901234567")).toBeFalsy()
       expect(isAllowedNumericInputValue("123.1234", 3)).toBeFalsy()
+    })
+  })
+})
+
+describe("isAllowedAddressHexInputValue()", () => {
+  describe("when valid", () => {
+    test("should return true", () => {
+      expect(isAllowedAddressHexInputValue("")).toBeTruthy()
+      expect(isAllowedAddressHexInputValue("0")).toBeTruthy()
+      expect(isAllowedAddressHexInputValue("0x")).toBeTruthy()
+      expect(isAllowedAddressHexInputValue("0x0")).toBeTruthy()
+      expect(isAllowedAddressHexInputValue("0xabc123")).toBeTruthy()
+      expect(isAllowedAddressHexInputValue("0xABc123")).toBeTruthy()
+    })
+  })
+  describe("when invalid", () => {
+    test("should return false", () => {
+      expect(isAllowedAddressHexInputValue("x")).toBeFalsy()
+      expect(isAllowedAddressHexInputValue("1x")).toBeFalsy()
+      expect(isAllowedAddressHexInputValue("0X")).toBeFalsy()
+      expect(isAllowedAddressHexInputValue("0x0x")).toBeFalsy()
+      expect(isAllowedAddressHexInputValue("0x0x123")).toBeFalsy()
+      expect(isAllowedAddressHexInputValue("foo")).toBeFalsy()
     })
   })
 })

--- a/packages/extension/test/addresses.test.ts
+++ b/packages/extension/test/addresses.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest"
 
-import { addressSchema } from "../src/ui/services/addresses"
+import { addressSchema, isEqualAddress } from "../src/ui/services/addresses"
 
 describe("address input", () => {
   test("should not allow ethereum addresses", async () => {
@@ -43,5 +43,51 @@ describe("address input", () => {
       "0x033D2A165d2a2aE64cBaF8e6DFF7F0c1974d0f41cD4F0c24d273373D4837BcFd"
     const result = await addressSchema.isValid(address)
     expect(result).toBe(false)
+  })
+})
+
+describe("isEqualAddress", () => {
+  describe("when valid", () => {
+    test("should match same address", () => {
+      expect(
+        isEqualAddress(
+          "0x033d2a165d2a2ae64cbaf8e6dff7f0c1974d0f41cd4f0c24d273373d4837bcfd",
+          "0x033d2a165d2a2ae64cbaf8e6dff7f0c1974d0f41cd4f0c24d273373d4837bcfd",
+        ),
+      ).toBe(true)
+    })
+    test("should match same address regardless of zero padding", () => {
+      expect(
+        isEqualAddress(
+          "0x33d2a165d2a2ae64cbaf8e6dff7f0c1974d0f41cd4f0c24d273373d4837bcfd",
+          "0x033d2a165d2a2ae64cbaf8e6dff7f0c1974d0f41cd4f0c24d273373d4837bcfd",
+        ),
+      ).toBe(true)
+      expect(
+        isEqualAddress(
+          "33d2a165d2a2ae64cbaf8e6dff7f0c1974d0f41cd4f0c24d273373d4837bcfd",
+          "0x033d2a165d2a2ae64cbaf8e6dff7f0c1974d0f41cd4f0c24d273373d4837bcfd",
+        ),
+      ).toBe(true)
+    })
+    test("should match regardless of case", () => {
+      expect(
+        isEqualAddress(
+          "0x033d2a165d2a2ae64cbaf8e6dff7f0c1974d0f41cd4f0c24d273373d4837bcfd",
+          "0x033D2A165D2A2AE64CBAF8E6DFF7F0C1974D0F41CD4F0C24D273373D4837BCFD",
+        ),
+      ).toBe(true)
+    })
+  })
+  describe("when invalid", () => {
+    test("should return false without throwing", () => {
+      expect(
+        isEqualAddress(
+          "0x033d2a165d2a2ae64cbaf8e6dff7f0c1974d0f41cd4f0c24d273373d4837bcfd",
+          "foo",
+        ),
+      ).toBe(false)
+      expect(isEqualAddress("foo", "foo")).toBe(false)
+    })
   })
 })


### PR DESCRIPTION
Adds optional restriction to input that only allow user to type or paste a `0x0abc...` address. Adds additional changes and tests for address function(s) which were throwing on invalid input.