### PR TITLE
fix(storybook): broken docs layout

### DIFF
--- a/packages/storybook/.storybook/decorators.tsx
+++ b/packages/storybook/.storybook/decorators.tsx
@@ -7,6 +7,7 @@ import {
 } from "@argent-x/extension/src/ui/theme"
 import { ThemeProvider as MuiThemeProvider } from "@mui/material"
 import React from "react"
+import { createGlobalStyle } from "styled-components"
 
 /** polyfill browser extension storage  */
 global.chrome = {
@@ -20,6 +21,14 @@ global.chrome = {
   storage: chromeStorageMock,
 }
 
+/** remove explicit width and height constraints which otherwise impact Docs */
+const StorybookGlobalStyle = createGlobalStyle`
+  html, body {
+    min-width: unset;
+    min-height: unset;
+  }
+`
+
 export const decorators = [
   (Story) => (
     <MuiThemeProvider theme={muiTheme}>
@@ -27,7 +36,8 @@ export const decorators = [
         href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;600;700;900&display=swap"
         rel="stylesheet"
       />
-      <FixedGlobalStyle extensionIsInTab={false} />
+      <FixedGlobalStyle extensionIsInTab />
+      <StorybookGlobalStyle />
       <StyledComponentsThemeProvider>
         <ThemedGlobalStyle />
         <Story />

--- a/packages/storybook/.storybook/preview-head.html
+++ b/packages/storybook/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<style>
+    /** targets the width of the preview in Docs, 360+40+2 to account for additional Storybook padding and border */
+    .sbdocs.sbdocs-preview {
+        max-width: 402px;
+    }
+</style>

--- a/packages/storybook/.storybook/preview.ts
+++ b/packages/storybook/.storybook/preview.ts
@@ -1,3 +1,15 @@
+import { INITIAL_VIEWPORTS } from "@storybook/addon-viewport"
+
+const CUSTOM_VIEWPORTS = {
+  extension: {
+    name: "Extension",
+    styles: {
+      width: "360px",
+      height: "600px",
+    },
+  },
+}
+
 export const parameters = {
   backgrounds: {
     default: "Extension",
@@ -26,6 +38,13 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+  },
+  viewport: {
+    viewports: {
+      ...INITIAL_VIEWPORTS,
+      ...CUSTOM_VIEWPORTS,
+    },
+    defaultViewport: "extension",
   },
 }
 


### PR DESCRIPTION
Improve Storybook config to use extension dimensions without breaking Docs layout