### PR TITLE
fix: crushed icon when title is long

### DIFF
--- a/packages/extension/src/ui/features/actions/connectDapp/DappIcon.tsx
+++ b/packages/extension/src/ui/features/actions/connectDapp/DappIcon.tsx
@@ -5,6 +5,7 @@ import { useDappDisplayAttributes } from "./useDappDisplayAttributes"
 
 interface IDappIcon {
   host: string
+  useDappDisplayAttributesImpl?: typeof useDappDisplayAttributes
 }
 
 interface IContainer {
@@ -21,7 +22,11 @@ const Container = styled.div<IContainer>`
   background-image: ${({ iconUrl }) => (iconUrl ? `url(${iconUrl})` : "none")};
 `
 
-export const DappIcon: FC<IDappIcon> = ({ host, ...rest }) => {
-  const dappDisplayAttributes = useDappDisplayAttributes(host)
+export const DappIcon: FC<IDappIcon> = ({
+  host,
+  useDappDisplayAttributesImpl = useDappDisplayAttributes,
+  ...rest
+}) => {
+  const dappDisplayAttributes = useDappDisplayAttributesImpl(host)
   return <Container iconUrl={dappDisplayAttributes?.iconUrl} {...rest} />
 }

--- a/packages/extension/src/ui/features/actions/transaction/fields/DappContractField.tsx
+++ b/packages/extension/src/ui/features/actions/transaction/fields/DappContractField.tsx
@@ -14,9 +14,15 @@ import {
 import { DappIcon } from "../../connectDapp/DappIcon"
 import { useDappDisplayAttributes } from "../../connectDapp/useDappDisplayAttributes"
 
+const DappFieldValue = styled(FieldValue)`
+  margin-left: 8px;
+`
+
 const DappIconContainer = styled.div`
   width: 24px;
   height: 24px;
+  display: flex;
+  flex-shrink: 0;
 `
 
 export const MaybeDappContractField: FC<{ contractAddress: string }> = ({
@@ -31,20 +37,29 @@ export const MaybeDappContractField: FC<{ contractAddress: string }> = ({
 
 export const DappContractField: FC<{
   knownContract: Omit<KnownDapp, "contracts">
-}> = ({ knownContract }) => {
+  useDappDisplayAttributesImpl?: typeof useDappDisplayAttributes
+}> = ({
+  knownContract,
+  useDappDisplayAttributesImpl = useDappDisplayAttributes,
+}) => {
   const host = knownContract.hosts[0]
-  const dappDisplayAttributes = useDappDisplayAttributes(host)
+  const dappDisplayAttributes = useDappDisplayAttributesImpl(host)
   return (
-    <Field>
-      <FieldKey>Dapp</FieldKey>
-      <FieldValue>
-        <DappIconContainer>
-          <DappIcon host={host} />
-        </DappIconContainer>
-        <LeftPaddedField>
-          {dappDisplayAttributes?.title || host}
-        </LeftPaddedField>
-      </FieldValue>
-    </Field>
+    <>
+      <Field>
+        <FieldKey>Dapp</FieldKey>
+        <DappFieldValue>
+          <DappIconContainer>
+            <DappIcon
+              host={host}
+              useDappDisplayAttributesImpl={useDappDisplayAttributesImpl}
+            />
+          </DappIconContainer>
+          <LeftPaddedField>
+            {dappDisplayAttributes?.title || host}
+          </LeftPaddedField>
+        </DappFieldValue>
+      </Field>
+    </>
   )
 }

--- a/packages/extension/src/ui/features/actions/transaction/fields/DappContractField.tsx
+++ b/packages/extension/src/ui/features/actions/transaction/fields/DappContractField.tsx
@@ -45,21 +45,19 @@ export const DappContractField: FC<{
   const host = knownContract.hosts[0]
   const dappDisplayAttributes = useDappDisplayAttributesImpl(host)
   return (
-    <>
-      <Field>
-        <FieldKey>Dapp</FieldKey>
-        <DappFieldValue>
-          <DappIconContainer>
-            <DappIcon
-              host={host}
-              useDappDisplayAttributesImpl={useDappDisplayAttributesImpl}
-            />
-          </DappIconContainer>
-          <LeftPaddedField>
-            {dappDisplayAttributes?.title || host}
-          </LeftPaddedField>
-        </DappFieldValue>
-      </Field>
-    </>
+    <Field>
+      <FieldKey>Dapp</FieldKey>
+      <DappFieldValue>
+        <DappIconContainer>
+          <DappIcon
+            host={host}
+            useDappDisplayAttributesImpl={useDappDisplayAttributesImpl}
+          />
+        </DappIconContainer>
+        <LeftPaddedField>
+          {dappDisplayAttributes?.title || host}
+        </LeftPaddedField>
+      </DappFieldValue>
+    </Field>
   )
 }

--- a/packages/storybook/src/ui/components/DappContractField.stories.tsx
+++ b/packages/storybook/src/ui/components/DappContractField.stories.tsx
@@ -1,0 +1,32 @@
+import { knownDapps } from "@argent-x/extension/src/shared/knownDapps"
+import { FieldGroup } from "@argent-x/extension/src/ui/components/Fields"
+import { DappContractField } from "@argent-x/extension/src/ui/features/actions/transaction/fields/DappContractField"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+
+export default {
+  title: "components/DappContractField",
+  component: DappContractField,
+} as ComponentMeta<typeof DappContractField>
+
+const Template: ComponentStory<typeof DappContractField> = (props) => (
+  <FieldGroup>
+    <DappContractField {...props}></DappContractField>
+  </FieldGroup>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  knownContract: knownDapps[0],
+}
+
+export const LongTitle = Template.bind({})
+LongTitle.args = {
+  knownContract: knownDapps[0],
+  useDappDisplayAttributesImpl: (_host: string) => {
+    return {
+      title:
+        "Lorem ipsum dolor sit amet, consec tetur adipi scing elit. Lectus nisl, diam iac ulis portt itor.",
+      iconUrl: "https://aspect.co/img/company/logo512.png",
+    }
+  },
+}


### PR DESCRIPTION
Fixes css for dapp contract field with very long title, adds storybook and stories

<img width="343" alt="Screenshot 2022-09-14 at 14 27 56" src="https://user-images.githubusercontent.com/175607/190167180-123ec5fb-f14b-49c9-b585-c01338a100b4.png">

<img width="345" alt="Screenshot 2022-09-14 at 14 28 01" src="https://user-images.githubusercontent.com/175607/190167184-76b7bbfa-870a-4060-ba3a-f1342931e1a6.png">
