### PR TITLE
fix(ui): check and ignore sequencer transfers

### DIFF
--- a/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/__fixtures__/explorer-transactions/goerli-alpha/erc20-transfer-with-sequencer-event.json
+++ b/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/__fixtures__/explorer-transactions/goerli-alpha/erc20-transfer-with-sequencer-event.json
@@ -1,0 +1,84 @@
+{
+  "id": "0x4e5f29b8dfe0e25c782fa64f3fae12603686f8a27375ed015a348dde2e4f034",
+  "blockNumber": 299220,
+  "timestamp": 1660823428,
+  "transactionHash": "0x4e5f29b8dfe0e25c782fa64f3fae12603686f8a27375ed015a348dde2e4f034",
+  "contractAddress": "0x5f1f0a38429dcab9ffd8a786c0d827e84c1cbd8f60243e6d25d066a13af4a25",
+  "entryPoint": "__execute__",
+  "maxFee": "0xdc3e44bc4a3",
+  "actualFee": "0x92d42dd552c",
+  "status": "ACCEPTED_ON_L2",
+  "statusData": "",
+  "events": [
+    {
+      "name": "Transfer",
+      "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+      "parameters": [
+        {
+          "name": "from_",
+          "value": "0x5f1f0a38429dcab9ffd8a786c0d827e84c1cbd8f60243e6d25d066a13af4a25"
+        },
+        {
+          "name": "to",
+          "value": "0x5417fc252d9b7b6ea311485a9e946cc814e3aa4d00f740f7e5f6b11ce0db9fa"
+        },
+        {
+          "name": "value",
+          "value": "1000000000000000"
+        }
+      ]
+    },
+    {
+      "name": "transaction_executed",
+      "address": "0x5f1f0a38429dcab9ffd8a786c0d827e84c1cbd8f60243e6d25d066a13af4a25",
+      "parameters": [
+        {
+          "name": "hash",
+          "value": "0x4e5f29b8dfe0e25c782fa64f3fae12603686f8a27375ed015a348dde2e4f034"
+        },
+        {
+          "name": "response_len",
+          "value": "0x1"
+        },
+        {
+          "name": "response",
+          "value": ["0x1"]
+        }
+      ]
+    },
+    {
+      "name": "Transfer",
+      "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+      "parameters": [
+        {
+          "name": "from_",
+          "value": "0x5f1f0a38429dcab9ffd8a786c0d827e84c1cbd8f60243e6d25d066a13af4a25"
+        },
+        {
+          "name": "to",
+          "value": "0x46a89ae102987331d369645031b49c27738ed096f2789c24449966da4c6de6b"
+        },
+        {
+          "name": "value",
+          "value": "1162676101422"
+        }
+      ]
+    }
+  ],
+  "calls": [
+    {
+      "name": "transfer",
+      "address": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+      "parameters": [
+        {
+          "name": "recipient",
+          "value": "0x5417fc252d9b7b6ea311485a9e946cc814e3aa4d00f740f7e5f6b11ce0db9fa"
+        },
+        {
+          "name": "amount",
+          "value": "1000000000000000"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/__fixtures__/explorer-transactions/goerli-alpha/index.ts
+++ b/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/__fixtures__/explorer-transactions/goerli-alpha/index.ts
@@ -5,6 +5,7 @@ import erc20MintTestToken from "./erc20-mint-test-token.json"
 import erc20SwapAlphaRoad from "./erc20-swap-alpha-road.json"
 import erc20SwapJediswap from "./erc20-swap-jediswap.json"
 import erc20SwapMySwap from "./erc20-swap-my-swap.json"
+import erc20TransferWithSequencerEvent from "./erc20-transfer-with-sequencer-event.json"
 import erc20Transfer from "./erc20-transfer.json"
 import erc721MintAspect from "./erc721-mint-aspect.json"
 import erc721MintMintSquare from "./erc721-mint-mint-square.json"
@@ -24,6 +25,7 @@ export {
   erc20SwapJediswap,
   erc20SwapMySwap,
   erc20Transfer,
+  erc20TransferWithSequencerEvent /** {@link https://github.com/eqlabs/pathfinder/issues/569} */,
   erc721MintAspect,
   erc721MintMintSquare,
   erc721Transfer,

--- a/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/fingerprintExplorerTransaction.test.ts
+++ b/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/fingerprintExplorerTransaction.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "vitest"
 
-import { IExplorerTransaction } from "../../../../../../shared/explorer/type"
-import { fingerprintExplorerTransaction } from "..//fingerprintExplorerTransaction"
+import {
+  IExplorerTransaction,
+  IExplorerTransactionEvent,
+} from "../../../../../../shared/explorer/type"
+import {
+  fingerprintExplorerTransaction,
+  isEthTransferToSequencer,
+} from "../fingerprintExplorerTransaction"
 import {
   accountCreated,
   accountCreatedAlt,
@@ -16,10 +22,37 @@ import {
   erc20SwapJediswap,
   erc20SwapMySwap,
   erc20Transfer,
+  erc20TransferWithSequencerEvent,
   erc721MintAspect,
   erc721MintMintSquare,
   erc721Transfer,
 } from "./__fixtures__/explorer-transactions/goerli-alpha"
+
+describe("isEthTransferToSequencer", () => {
+  describe("when valid", () => {
+    describe("when the event is a Transfer to sequencer", () => {
+      test("should return true", () => {
+        const event = erc20TransferWithSequencerEvent
+          .events[2] as IExplorerTransactionEvent
+        expect(isEthTransferToSequencer(event)).toBe(true)
+      })
+    })
+    describe("when the event is not a Transfer to sequencer", () => {
+      test("should return false", () => {
+        const event = erc20TransferWithSequencerEvent
+          .events[0] as IExplorerTransactionEvent
+        expect(isEthTransferToSequencer(event)).toBe(false)
+      })
+    })
+  })
+  describe("when invalid", () => {
+    test("should return false", () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      expect(isEthTransferToSequencer({})).toBe(false)
+    })
+  })
+})
 
 describe("fingerprintExplorerTransaction", () => {
   describe("when valid", () => {
@@ -92,6 +125,11 @@ describe("fingerprintExplorerTransaction", () => {
       )
       expect(
         fingerprintExplorerTransaction(erc20Transfer as IExplorerTransaction),
+      ).toMatchInlineSnapshot('"events[Transfer] calls[transfer]"')
+      expect(
+        fingerprintExplorerTransaction(
+          erc20TransferWithSequencerEvent as IExplorerTransaction,
+        ),
       ).toMatchInlineSnapshot('"events[Transfer] calls[transfer]"')
       expect(
         fingerprintExplorerTransaction(

--- a/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/transformExplorerTransaction.test.ts
+++ b/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/transformExplorerTransaction.test.ts
@@ -16,6 +16,7 @@ import {
   erc20SwapJediswap,
   erc20SwapMySwap,
   erc20Transfer,
+  erc20TransferWithSequencerEvent,
   erc721MintAspect,
   erc721MintMintSquare,
   erc721Transfer,
@@ -28,6 +29,36 @@ describe("transformExplorerTransaction", () => {
       expect(
         transformExplorerTransaction({
           explorerTransaction: erc20Transfer as IExplorerTransaction,
+          accountAddress: "0x0",
+        }),
+      ).toMatchInlineSnapshot(`
+        {
+          "action": "TRANSFER",
+          "actualFee": "10089999979820",
+          "amount": "1000000000000000",
+          "date": "2022-08-18T11:50:28.000Z",
+          "displayName": "Transfer",
+          "entity": "TOKEN",
+          "fromAddress": "0x5f1f0a38429dcab9ffd8a786c0d827e84c1cbd8f60243e6d25d066a13af4a25",
+          "maxFee": "15134999954595",
+          "toAddress": "0x5417fc252d9b7b6ea311485a9e946cc814e3aa4d00f740f7e5f6b11ce0db9fa",
+          "token": {
+            "address": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+            "decimals": 18,
+            "image": "https://dv3jj1unlp2jl.cloudfront.net/128/color/eth.png",
+            "name": "Ether",
+            "network": "mainnet-alpha",
+            "networkId": "mainnet-alpha",
+            "showAlways": true,
+            "symbol": "ETH",
+          },
+          "tokenAddress": "0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        }
+      `)
+      expect(
+        transformExplorerTransaction({
+          explorerTransaction:
+            erc20TransferWithSequencerEvent as IExplorerTransaction,
           accountAddress: "0x0",
         }),
       ).toMatchInlineSnapshot(`

--- a/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/fingerprintExplorerTransaction.ts
+++ b/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/fingerprintExplorerTransaction.ts
@@ -4,13 +4,34 @@
  * This is used to match known transaction types in the transformer
  */
 
-import { IExplorerTransaction } from "../../../../../shared/explorer/type"
+import {
+  IExplorerTransaction,
+  IExplorerTransactionEvent,
+} from "../../../../../shared/explorer/type"
+import { isEqualAddress } from "../../../../services/addresses"
+import { getParameter } from "./getParameter"
+
+const GOERLI_SEQUENCER_ADDRESS =
+  "0x46a89ae102987331d369645031b49c27738ed096f2789c24449966da4c6de6b"
+
+/** Identify sequencer fee transfer events so they can be excluded {@link https://github.com/eqlabs/pathfinder/issues/569} */
+
+export const isEthTransferToSequencer = (event: IExplorerTransactionEvent) => {
+  if (event.name === "Transfer") {
+    const toAddress = getParameter(event.parameters, "to")
+    if (toAddress && isEqualAddress(toAddress, GOERLI_SEQUENCER_ADDRESS)) {
+      return true
+    }
+  }
+  return false
+}
 
 export const fingerprintExplorerTransaction = (
   explorerTransaction: IExplorerTransaction,
 ) => {
   const events = explorerTransaction.events
-    ?.map((event) => event.name)
+    ?.filter((event) => !isEthTransferToSequencer(event))
+    .map((event) => event.name)
     .filter((name) => name !== "transaction_executed")
   const calls = explorerTransaction.calls?.map((call) => call.name)
   const elements = []


### PR DESCRIPTION
Adds a check for unexpected events that are gas fee transfers to sequencer.