### PR TITLE
fix: mainnet rich transactions

### DIFF
--- a/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/fingerprintExplorerTransaction.test.ts
+++ b/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/__test__/fingerprintExplorerTransaction.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, test } from "vitest"
 
-import {
-  IExplorerTransaction,
-  IExplorerTransactionEvent,
-} from "../../../../../../shared/explorer/type"
-import {
-  fingerprintExplorerTransaction,
-  isEthTransferToSequencer,
-} from "../fingerprintExplorerTransaction"
+import { IExplorerTransaction } from "../../../../../../shared/explorer/type"
+import { fingerprintExplorerTransaction } from "../fingerprintExplorerTransaction"
 import {
   accountCreated,
   accountCreatedAlt,
@@ -27,32 +21,6 @@ import {
   erc721MintMintSquare,
   erc721Transfer,
 } from "./__fixtures__/explorer-transactions/goerli-alpha"
-
-describe("isEthTransferToSequencer", () => {
-  describe("when valid", () => {
-    describe("when the event is a Transfer to sequencer", () => {
-      test("should return true", () => {
-        const event = erc20TransferWithSequencerEvent
-          .events[2] as IExplorerTransactionEvent
-        expect(isEthTransferToSequencer(event)).toBe(true)
-      })
-    })
-    describe("when the event is not a Transfer to sequencer", () => {
-      test("should return false", () => {
-        const event = erc20TransferWithSequencerEvent
-          .events[0] as IExplorerTransactionEvent
-        expect(isEthTransferToSequencer(event)).toBe(false)
-      })
-    })
-  })
-  describe("when invalid", () => {
-    test("should return false", () => {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      expect(isEthTransferToSequencer({})).toBe(false)
-    })
-  })
-})
 
 describe("fingerprintExplorerTransaction", () => {
   describe("when valid", () => {

--- a/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/fingerprintExplorerTransaction.ts
+++ b/packages/extension/src/ui/features/accountActivity/transform/explorerTransaction/fingerprintExplorerTransaction.ts
@@ -4,35 +4,28 @@
  * This is used to match known transaction types in the transformer
  */
 
-import {
-  IExplorerTransaction,
-  IExplorerTransactionEvent,
-} from "../../../../../shared/explorer/type"
-import { isEqualAddress } from "../../../../services/addresses"
-import { getParameter } from "./getParameter"
-
-const GOERLI_SEQUENCER_ADDRESS =
-  "0x46a89ae102987331d369645031b49c27738ed096f2789c24449966da4c6de6b"
-
-/** Identify sequencer fee transfer events so they can be excluded {@link https://github.com/eqlabs/pathfinder/issues/569} */
-
-export const isEthTransferToSequencer = (event: IExplorerTransactionEvent) => {
-  if (event.name === "Transfer") {
-    const toAddress = getParameter(event.parameters, "to")
-    if (toAddress && isEqualAddress(toAddress, GOERLI_SEQUENCER_ADDRESS)) {
-      return true
-    }
-  }
-  return false
-}
+import { IExplorerTransaction } from "../../../../../shared/explorer/type"
 
 export const fingerprintExplorerTransaction = (
   explorerTransaction: IExplorerTransaction,
 ) => {
-  const events = explorerTransaction.events
-    ?.filter((event) => !isEthTransferToSequencer(event))
-    .map((event) => event.name)
-    .filter((name) => name !== "transaction_executed")
+  /**
+   * Create an array of event names up to but excluding `transaction_executed`
+   *
+   * There may or may not be an additional `Transfer` fee event to the sequencer after this
+   *
+   * {@link https://github.com/eqlabs/pathfinder/issues/569}
+   */
+  let events: string[] | undefined
+  if (Array.isArray(explorerTransaction.events)) {
+    events = []
+    for (const event of explorerTransaction.events) {
+      if (event.name === "transaction_executed") {
+        break
+      }
+      events.push(event.name)
+    }
+  }
   const calls = explorerTransaction.calls?.map((call) => call.name)
   const elements = []
   if (events !== undefined) {


### PR DESCRIPTION
Ignore additional sequencer fee `Transfer` event after `transaction_executed` which was introduced in 0.10. This additional event breaks transaction identification, previous fix was tied to goerli but this should be network agnostic.