### PR TITLE
fix: copy address

### DIFF
--- a/packages/extension/src/ui/features/funding/FundingQrCodeScreen.tsx
+++ b/packages/extension/src/ui/features/funding/FundingQrCodeScreen.tsx
@@ -1,10 +1,11 @@
-import { FC } from "react"
+import { FC, useCallback, useRef } from "react"
 import styled from "styled-components"
 
 import { AccountAddress, AccountName } from "../../components/Address"
+import { CopyIconButton } from "../../components/CopyIconButton"
 import { IconBar } from "../../components/IconBar"
 import { PageWrapper } from "../../components/Page"
-import { formatFullAddress } from "../../services/addresses"
+import { formatFullAddress, normalizeAddress } from "../../services/addresses"
 import { usePageTracking } from "../../services/analytics"
 import {
   getAccountName,
@@ -18,12 +19,54 @@ const Container = styled.div`
   text-align: center;
 `
 
+const StyledCopyIconButton = styled(CopyIconButton)`
+  margin-top: 16px;
+  width: auto;
+`
+
 export const FundingQrCodeScreen: FC = () => {
+  const addressRef = useRef<HTMLParagraphElement | null>(null)
   const account = useSelectedAccount()
   usePageTracking("addFundsFromOtherAccount", {
     networkId: account?.networkId || "unknown",
   })
   const { accountNames } = useAccountMetadata()
+  const copyAccountAddress = account ? normalizeAddress(account.address) : ""
+
+  /** Intercept 'copy' event and replace fragmented address with plain text address */
+  const onCopyAddress = useCallback(
+    (e: ClipboardEvent) => {
+      if (e.clipboardData) {
+        e.clipboardData.setData("text/plain", copyAccountAddress)
+        e.preventDefault()
+      }
+    },
+    [copyAccountAddress],
+  )
+
+  /** Intercept 'mouseup' and automatically select the entire address */
+  const onSelectAddress = useCallback((_e: Event) => {
+    const selection = window.getSelection()
+    if (selection && addressRef.current) {
+      selection.setBaseAndExtent(addressRef.current, 0, addressRef.current, 1)
+    }
+  }, [])
+
+  /** Add / remove events when ref changes */
+  const setAddressRef = useCallback(
+    (ref: HTMLParagraphElement) => {
+      if (addressRef.current) {
+        addressRef.current.removeEventListener("copy", onCopyAddress)
+        addressRef.current.removeEventListener("mouseup", onSelectAddress)
+      }
+      addressRef.current = ref
+      if (addressRef.current) {
+        addressRef.current.addEventListener("copy", onCopyAddress)
+        addressRef.current.addEventListener("mouseup", onSelectAddress)
+      }
+    },
+    [onCopyAddress, onSelectAddress],
+  )
 
   return (
     <>
@@ -33,9 +76,15 @@ export const FundingQrCodeScreen: FC = () => {
           <Container>
             <QrCode size={220} data={account?.address} />
             <AccountName>{getAccountName(account, accountNames)}</AccountName>
-            <AccountAddress aria-label="Full account address">
+            <AccountAddress
+              ref={setAddressRef}
+              aria-label="Full account address"
+            >
               {formatFullAddress(account.address)}
             </AccountAddress>
+            <StyledCopyIconButton size="s" copyValue={copyAccountAddress}>
+              Copy address
+            </StyledCopyIconButton>
           </Container>
         )}
       </PageWrapper>

--- a/packages/extension/src/ui/services/addresses.ts
+++ b/packages/extension/src/ui/services/addresses.ts
@@ -1,4 +1,3 @@
-import { isHexString } from "ethers/lib/utils"
 import {
   constants,
   getChecksumAddress,


### PR DESCRIPTION
Adds a button which copies the checksummed address on click. Intercepts mouseup on the address field to select the whole text. Intercepts copy event to replace spaced address with checksummed.


https://user-images.githubusercontent.com/175607/194035093-09267903-7134-4962-83d1-9c6218d070f6.mov

