### PR TITLE
fix: don't show empty screen when closing account list

### DIFF
--- a/packages/extension/src/ui/features/accounts/AccountListScreen.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountListScreen.tsx
@@ -153,16 +153,19 @@ export const AccountListScreen: FC = () => {
 
   const { scrollRef, scroll } = useScroll()
 
+  const onClose = useCallback(() => {
+    if (returnTo) {
+      navigate(returnTo)
+    } else {
+      navigate(-1)
+    }
+  }, [navigate, returnTo])
+
   return (
     <>
       <NavigationBar
         scroll={scroll}
-        leftButton={
-          <BarCloseButton
-            onClick={returnTo ? () => navigate(returnTo) : undefined}
-            disabled={isDeploying}
-          />
-        }
+        leftButton={<BarCloseButton onClick={onClose} disabled={isDeploying} />}
         title={"My accounts"}
         rightButton={
           <BarIconButton

--- a/packages/extension/src/ui/features/accounts/AccountScreen.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountScreen.tsx
@@ -1,5 +1,7 @@
 import { FC, ReactNode } from "react"
+import { useNavigate } from "react-router-dom"
 
+import { routes } from "../../routes"
 import { assertNever } from "../../services/assertNever"
 import { AccountActivityContainer } from "../accountActivity/AccountActivity"
 import { AccountCollections } from "../accountNfts/AccountCollections"
@@ -21,10 +23,11 @@ export const AccountScreen: FC<AccountScreenProps> = ({ tab }) => {
   )
   const shouldShowFullScreenStatusMessage =
     useShouldShowFullScreenStatusMessage()
+  const navigate = useNavigate()
 
   let body: ReactNode
   if (!account) {
-    body = <></>
+    navigate(routes.accounts())
   } else if (showMigrationScreen) {
     return (
       <DeprecatedAccountScreen


### PR DESCRIPTION
Fixes an issue where the new account list has a close button that may cause user to see an empty screen. This state will not be possible once the full UI implementation work is completed.