### PR TITLE
fix: explicit initial dark mode

### DIFF
--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider as ArgentTheme } from "@argent/ui"
+import { InitiallyDarkThemeProvider as ArgentTheme } from "@argent/ui"
 import { localStorageManager } from "@chakra-ui/react"
 import { ThemeProvider as MuiThemeProvider } from "@mui/material"
 import { FC, Suspense, useEffect } from "react"

--- a/packages/ui/src/theme/index.tsx
+++ b/packages/ui/src/theme/index.tsx
@@ -55,6 +55,22 @@ export const theme = {
   colors /** omits default chakra colours */,
 } as UITheme
 
+export const initiallyDarkTheme = {
+  ...theme,
+  config: {
+    ...theme.config,
+    initialColorMode: "dark",
+  },
+} as UITheme
+
+/** Theme with initial color mode "light" also see {@link InitiallyDarkThemeProvider} */
 export const ThemeProvider = ({ children }: ChakraProviderProps) => (
   <ChakraProvider theme={theme}>{children}</ChakraProvider>
+)
+
+/** In a production build this ensures that global styles are initially "dark" */
+export const InitiallyDarkThemeProvider = ({
+  children,
+}: ChakraProviderProps) => (
+  <ChakraProvider theme={initiallyDarkTheme}>{children}</ChakraProvider>
 )


### PR DESCRIPTION
This PR fixes an issue in a production build where the onboarding background was initially "light".