### PR TITLE
fix: rework enforced dark mode

### DIFF
--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -1,7 +1,6 @@
-import { InitiallyDarkThemeProvider as ArgentTheme } from "@argent/ui"
-import { localStorageManager } from "@chakra-ui/react"
+import { ThemeProvider as ArgentTheme, SetDarkMode } from "@argent/ui"
 import { ThemeProvider as MuiThemeProvider } from "@mui/material"
-import { FC, Suspense, useEffect } from "react"
+import { FC, Suspense } from "react"
 import { SWRConfig } from "swr"
 
 import AppErrorBoundaryFallback from "./AppErrorBoundaryFallback"
@@ -19,10 +18,7 @@ import { ThemeProvider, muiTheme } from "./theme"
 export const App: FC = () => {
   useTracking()
   useSentryInit()
-  useEffect(() => {
-    /** Ensure colour mode is dark - may previously have defaulted to 'white' */
-    localStorageManager.set("dark")
-  }, [])
+
   return (
     <SoftReloadProvider>
       <SWRConfig value={{ provider: () => swrCacheProvider }}>
@@ -35,6 +31,7 @@ export const App: FC = () => {
           />
           <ThemeProvider>
             <ArgentTheme>
+              <SetDarkMode />
               <AppDimensions>
                 {process.env.SHOW_DEV_UI && <DevUI />}
                 <ErrorBoundary fallback={<AppErrorBoundaryFallback />}>

--- a/packages/ui/src/theme/SetDarkMode.tsx
+++ b/packages/ui/src/theme/SetDarkMode.tsx
@@ -1,0 +1,29 @@
+import { useColorMode } from "@chakra-ui/react"
+import { FC, useEffect } from "react"
+
+/**
+ * In a production build this ensures that global styles are initially "dark"
+ *
+ * Must be a child of {@link ThemeProvider}
+ *
+ * @example
+ * ```ts
+ * import { ThemeProvider, SetDarkMode } from "@argent/ui"
+ *
+ * <ThemeProvider>
+ *   <SetDarkMode />
+ *   <App />
+ * </ThemeProvider>
+ * ```
+ */
+
+export const SetDarkMode: FC = () => {
+  const { colorMode, setColorMode } = useColorMode()
+  useEffect(() => {
+    /** Ensure colour mode is dark - may previously have defaulted to 'white' */
+    if (colorMode !== "dark") {
+      setColorMode("dark")
+    }
+  }, [colorMode, setColorMode])
+  return null
+}

--- a/packages/ui/src/theme/index.tsx
+++ b/packages/ui/src/theme/index.tsx
@@ -22,6 +22,7 @@ import { spacing } from "./spacing"
 import { typography } from "./typography"
 
 export { scrollbarStyle } from "./scrollbarStyle"
+export { SetDarkMode } from "./SetDarkMode"
 
 const config: ThemeConfig = {
   initialColorMode: "light",
@@ -62,22 +63,7 @@ export const theme = {
   colors /** omits default chakra colours */,
 } as UITheme
 
-export const initiallyDarkTheme = {
-  ...theme,
-  config: {
-    ...theme.config,
-    initialColorMode: "dark",
-  },
-} as UITheme
-
-/** Theme with initial color mode "light" also see {@link InitiallyDarkThemeProvider} */
+/** Theme with initial color mode "light" also see {@link SetDarkMode} */
 export const ThemeProvider = ({ children }: ChakraProviderProps) => (
   <ChakraProvider theme={theme}>{children}</ChakraProvider>
-)
-
-/** In a production build this ensures that global styles are initially "dark" */
-export const InitiallyDarkThemeProvider = ({
-  children,
-}: ChakraProviderProps) => (
-  <ChakraProvider theme={initiallyDarkTheme}>{children}</ChakraProvider>
 )


### PR DESCRIPTION
This PR reworks the method used to enforce 'dark' mode in the extension to use 'official' Chakra hooks