### PR TITLE
chore: memoize creation of provider for each baseUrl

### DIFF
--- a/packages/extension/src/shared/network/provider.ts
+++ b/packages/extension/src/shared/network/provider.ts
@@ -1,12 +1,21 @@
+import { memoize } from "lodash-es"
 import { SequencerProvider } from "starknet"
 import { SequencerProvider as SequencerProviderv4 } from "starknet4"
 
 import { Network } from "./type"
 
+const getProviderForBaseUrl = memoize((baseUrl: string) => {
+  return new SequencerProvider({ baseUrl })
+})
+
 export function getProvider(network: Network) {
-  return new SequencerProvider({ baseUrl: network.baseUrl })
+  return getProviderForBaseUrl(network.baseUrl)
 }
 
+const getProviderV4ForBaseUrl = memoize((baseUrl: string) => {
+  return new SequencerProviderv4({ baseUrl })
+})
+
 export function getProviderv4(network: Network) {
-  return new SequencerProviderv4({ baseUrl: network.baseUrl })
+  return getProviderV4ForBaseUrl(network.baseUrl)
 }


### PR DESCRIPTION
This PR makes an adjustment so that calls to `getProvider()` are memoized and create a single instance of `SequencerProvider()` for each `baseUrl`, rather than creating a new instance of `SequencerProvider()` each time it is called.