### PR TITLE
fix: update devnet eth address for v0.4.0

### DIFF
--- a/packages/extension/src/assets/default-tokens.json
+++ b/packages/extension/src/assets/default-tokens.json
@@ -36,7 +36,7 @@
     "showAlways": true
   },
   {
-    "address": "0x62230ea046a9a5fbc261ac77d03c8d41e5d442db2284587570ab46455fd2488",
+    "address": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
     "name": "Ether",
     "symbol": "ETH",
     "decimals": "18",


### PR DESCRIPTION
Updates localhost devnet token address for breaking change in devnet v0.4.0

https://github.com/Shard-Labs/starknet-devnet/releases/tag/v0.4.0