### PR TITLE
feat: use new locally generated avatars

### DIFF
--- a/packages/extension/src/shared/avatarImage.ts
+++ b/packages/extension/src/shared/avatarImage.ts
@@ -1,0 +1,40 @@
+const getInitials = (name: string) => {
+  let initials = name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+  if (initials.length < 2) {
+    initials = name[0] + name[1]
+  }
+  if (initials.length > 2) {
+    initials = initials.slice(0, 2)
+  }
+  return initials.toUpperCase()
+}
+
+const parseColor = (color: string) => {
+  const hex = color.replace("#", "")
+  if (!/^[0-9A-F]{6}$/i.test(hex)) {
+    throw new Error(`Invalid color ${color}`)
+  }
+  return `#${hex}`
+}
+
+export const generateAvatarImage = (
+  name: string,
+  options: { background: string; color?: string },
+) => {
+  // validate background and color are hex colors
+  const background = parseColor(options.background)
+  const color = parseColor(options.color ?? "#ffffff")
+
+  // get initials
+  const initials = getInitials(name)
+
+  // generate 64x64 svg with initials in the center (horizontal and vertical) with font color and background color and font family Helvetica
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+    <rect width="64" height="64" fill="${background}" />
+    <text x="50%" y="54%" dominant-baseline="middle" text-anchor="middle" fill="${color}" font-family="Helvetica" font-size="28">${initials}</text>
+    </svg>`
+  return `data:image/svg+xml;base64,${btoa(svg)}`
+}

--- a/packages/extension/src/shared/avatarImage.ts
+++ b/packages/extension/src/shared/avatarImage.ts
@@ -31,10 +31,10 @@ export const generateAvatarImage = (
   // get initials
   const initials = getInitials(name)
 
-  // generate 64x64 svg with initials in the center (horizontal and vertical) with font color and background color and font family Helvetica
+  // generate 64x64 svg with initials in the center (horizontal and vertical) with font color and background color and font family Helvetica (plus fallbacks)
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
     <rect width="64" height="64" fill="${background}" />
-    <text x="50%" y="54%" dominant-baseline="middle" text-anchor="middle" fill="${color}" font-family="Helvetica" font-size="28">${initials}</text>
+    <text x="50%" y="54%" dominant-baseline="middle" text-anchor="middle" font-size="28" font-family="Helvetica, Arial, sans-serif" fill="${color}">${initials}</text>
     </svg>`
   return `data:image/svg+xml;base64,${btoa(svg)}`
 }

--- a/packages/extension/src/ui/features/accountTokens/TokenIcon.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenIcon.tsx
@@ -1,6 +1,7 @@
 import { Circle, Image } from "@chakra-ui/react"
 import { ComponentProps, FC } from "react"
 
+import { generateAvatarImage } from "../../../shared/avatarImage"
 import { getColor } from "../accounts/accounts.service"
 
 export interface TokenIconProps
@@ -17,8 +18,8 @@ export const getTokenIconUrl = ({
   if (url && url.length) {
     return url
   }
-  const color = getColor(name)
-  return `https://eu.ui-avatars.com/api/?name=${name}&background=${color}&color=fff`
+  const background = getColor(name)
+  return generateAvatarImage(name, { background })
 }
 
 export const TokenIcon: FC<TokenIconProps> = ({ name, url, size, ...rest }) => {

--- a/packages/extension/src/ui/features/accounts/accounts.service.ts
+++ b/packages/extension/src/ui/features/accounts/accounts.service.ts
@@ -2,6 +2,7 @@ import { ethers } from "ethers"
 import { number } from "starknet"
 import { toBN } from "starknet/dist/utils/number"
 
+import { generateAvatarImage } from "../../../shared/avatarImage"
 import { BaseWalletAccount } from "../../../shared/wallet.model"
 import { accountsEqual } from "../../../shared/wallet.service"
 import { startSession } from "../../services/backgroundSessions"
@@ -60,8 +61,8 @@ export const getNetworkAccountImageUrl = ({
 }) => {
   const unpaddedAddress = stripAddressZeroPadding(accountAddress)
   const accountIdentifier = `${networkId}::${unpaddedAddress}`
-  const color = backgroundColor || getColor(accountIdentifier)
-  return `https://eu.ui-avatars.com/api?name=${accountName}&background=${color}&color=fff`
+  const background = backgroundColor || getColor(accountIdentifier)
+  return generateAvatarImage(accountName, { background })
 }
 
 const isAccountDeployed = (account: Account): boolean =>

--- a/packages/extension/src/ui/features/actions/connectDapp/useDappDisplayAttributes.ts
+++ b/packages/extension/src/ui/features/actions/connectDapp/useDappDisplayAttributes.ts
@@ -1,6 +1,7 @@
 import useSWRImmutable from "swr/immutable"
 import urlJoin from "url-join"
 
+import { generateAvatarImage } from "../../../../shared/avatarImage"
 import { getKnownDappForHost } from "../../../../shared/knownDapps"
 import { getBaseUrlForHost } from "../../../../shared/utils/url"
 import { getColor } from "../../accounts/accounts.service"
@@ -13,12 +14,12 @@ export interface IDappDisplayAttributes {
 export const getDappDisplayAttributes = async (
   host: string,
 ): Promise<IDappDisplayAttributes> => {
-  const color = getColor(host)
+  const background = getColor(host)
   const knownDapp = getKnownDappForHost(host)
   const title = knownDapp?.title || host
   const result: IDappDisplayAttributes = {
     title,
-    iconUrl: `https://eu.ui-avatars.com/api?name=${title}&background=${color}&color=fff`,
+    iconUrl: generateAvatarImage(title, { background }),
   }
 
   /** check if the icon still exists at the url */


### PR DESCRIPTION
removes the network requests (and dependence on) `eu.ui-avatars.com`

better late than never