### PR TITLE
fix: account list header is sticky

### DIFF
--- a/packages/extension/src/ui/AppRoutes.tsx
+++ b/packages/extension/src/ui/AppRoutes.tsx
@@ -132,7 +132,6 @@ const nonWalletRoutes = (
 const legacyUiWalletRoutes = (
   <>
     <Route path={routes.accountNft.path} element={<NftScreen />} />
-
     <Route path={routes.collectionNfts.path} element={<CollectionNfts />} />
     <Route
       path={routes.transactionDetail.path}
@@ -158,7 +157,6 @@ const legacyUiWalletRoutes = (
       path={routes.accountUpgradeV4.path}
       element={<UpgradeScreenV4 upgradeType={"account"} />}
     />
-    <Route path={routes.accounts.path} element={<AccountListScreen />} />
     <Route
       path={routes.accountsHidden.path}
       element={<AccountListHiddenScreen />}


### PR DESCRIPTION
Fixes an issue where a duplicate route was preventing the account list UI from displaying correctly with a sticky navigation bar.

After (navigation bar is sticky)
<img width="360" alt="Screenshot 2022-11-23 at 10 04 48" src="https://user-images.githubusercontent.com/175607/203520310-fe256950-94c3-4783-9cbb-c5f170a81b15.png">

---

Before (navigation bar scrolls off screen)
<img width="360" alt="Screenshot 2022-11-23 at 10 05 40" src="https://user-images.githubusercontent.com/175607/203520329-baf46fe9-7e69-4c3e-9887-ad5b17eed471.png">
