### PR TITLE
feat: show success message on submitting error

### DIFF
--- a/packages/extension/src/ui/components/ErrorBoundaryFallbackWithCopyError.tsx
+++ b/packages/extension/src/ui/components/ErrorBoundaryFallbackWithCopyError.tsx
@@ -1,3 +1,4 @@
+import { useToast } from "@argent/ui"
 import { Collapse } from "@mui/material"
 import * as Sentry from "@sentry/react"
 import { FC, useCallback, useEffect, useMemo, useState } from "react"
@@ -109,12 +110,21 @@ Unable to parse error
 export interface IErrorBoundaryFallbackWithCopyError
   extends ErrorBoundaryState {
   message?: string
+  /** overrides storage setting, used in Storybook */
+  privacyErrorReporting?: boolean
 }
 
 const ErrorBoundaryFallbackWithCopyError: FC<
   IErrorBoundaryFallbackWithCopyError
-> = ({ error, errorInfo, message = "Sorry, an error occurred" }) => {
+> = ({
+  error,
+  errorInfo,
+  message = "Sorry, an error occurred",
+  privacyErrorReporting: privacyErrorReportingProp,
+}) => {
   const [viewLogs, setViewLogs] = useState(false)
+
+  const toast = useToast()
 
   const hardResetAndReload = useHardResetAndReload()
   const errorPayload = useMemo(() => {
@@ -145,14 +155,26 @@ ${displayStack}
         scope.setExtra("submittedManually", manuallySubmitted)
         Sentry.captureException(error)
       })
+      if (manuallySubmitted) {
+        toast({
+          title: "The error was reported successfully",
+          status: "success",
+          duration: 3000,
+        })
+      }
     },
-    [error, errorInfo],
+    [error, errorInfo, toast],
   )
 
-  const privacyErrorReporting = useKeyValueStorage(
+  const privacyErrorReportingSetting = useKeyValueStorage(
     settingsStore,
     "privacyErrorReporting",
   )
+
+  const privacyErrorReporting =
+    privacyErrorReportingProp !== undefined
+      ? privacyErrorReportingProp
+      : privacyErrorReportingSetting
 
   const privacyAutomaticErrorReporting = useKeyValueStorage(
     settingsStore,

--- a/packages/storybook/src/ui/components/ErrorBoundary.stories.tsx
+++ b/packages/storybook/src/ui/components/ErrorBoundary.stories.tsx
@@ -1,0 +1,22 @@
+import ErrorBoundaryFallbackWithCopyError from "@argent-x/extension/src/ui/components/ErrorBoundaryFallbackWithCopyError"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+
+export default {
+  title: "components/ErrorBoundary",
+  component: ErrorBoundaryFallbackWithCopyError,
+} as ComponentMeta<typeof ErrorBoundaryFallbackWithCopyError>
+
+const Template: ComponentStory<typeof ErrorBoundaryFallbackWithCopyError> = (
+  props,
+) => (
+  <div style={{ width: "328px", height: "568px", display: "flex" }}>
+    <ErrorBoundaryFallbackWithCopyError
+      {...props}
+    ></ErrorBoundaryFallbackWithCopyError>
+  </div>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  privacyErrorReporting: true,
+}


### PR DESCRIPTION
Adds a toast success message when clicking the submit button, and adds a story demonstrating this

https://user-images.githubusercontent.com/175607/203747891-11e44e5a-6e2c-46bc-9df1-764d09075312.mov

