### PR TITLE
BLO-581 - fix(ui): improve handling of individual token errors

### DIFF
--- a/packages/extension/src/ui/features/accountTokens/tokens.service.ts
+++ b/packages/extension/src/ui/features/accountTokens/tokens.service.ts
@@ -119,7 +119,7 @@ export const fetchAllTokensBalance = async (
   tokenAddresses: string[],
   account: Account,
 ) => {
-  const response = await Promise.all(
+  const response = await Promise.allSettled(
     tokenAddresses.map((tokenAddress) => {
       return getTokenBalanceForAccount(tokenAddress, account)
     }),
@@ -128,7 +128,10 @@ export const fetchAllTokensBalance = async (
     const balance = response[i]
     return {
       ...acc,
-      [addr]: BigNumber.from(balance),
+      [addr]:
+        balance.status === "fulfilled"
+          ? BigNumber.from(balance.value)
+          : undefined, // Error will be surfaced to user by useTokenBalanceForAccount()
     }
   }, {})
 }


### PR DESCRIPTION
Use Promise.allSettled so a single failure doesn't break whole list

<img width="359" alt="Screenshot 2022-12-06 at 11 41 48" src="https://user-images.githubusercontent.com/175607/205902712-ba91f3b4-7c0c-42e9-8321-faafe402fbea.png">
