### PR TITLE
fix: multi deploy and analytics

### DIFF
--- a/packages/extension/src/background/accountDeploy.ts
+++ b/packages/extension/src/background/accountDeploy.ts
@@ -1,5 +1,5 @@
 import { ActionItem } from "../shared/actionQueue/types"
-import { BaseWalletAccount } from "../shared/wallet.model"
+import { BaseWalletAccount, WalletAccount } from "../shared/wallet.model"
 import { Queue } from "./actionQueue"
 
 export interface IDeployAccount {
@@ -15,4 +15,19 @@ export const deployAccountAction = async ({
     type: "DEPLOY_ACCOUNT_ACTION",
     payload: account,
   })
+}
+
+export const isAccountDeployed = async (
+  account: WalletAccount,
+  getClassAt: (address: string) => Promise<unknown>,
+) => {
+  if (!account.needsDeploy) {
+    return true
+  }
+  try {
+    await getClassAt(account.address)
+    return true
+  } catch (e) {
+    return false
+  }
 }

--- a/packages/extension/src/background/accountMessaging.ts
+++ b/packages/extension/src/background/accountMessaging.ts
@@ -78,19 +78,8 @@ export const handleAccountMessage: HandleMessage<AccountMessage> = async ({
           actionQueue,
         })
 
-        analytics.track("deployAccount", {
-          status: "success",
-          networkId: msg.data.networkId,
-        })
-
         return sendMessageToUi({ type: "DEPLOY_ACCOUNT_RES" })
       } catch (e) {
-        analytics.track("deployAccount", {
-          status: "failure",
-          networkId: msg.data.networkId,
-          errorMessage: `${e}`,
-        })
-
         return sendMessageToUi({ type: "DEPLOY_ACCOUNT_REJ" })
       }
     }

--- a/packages/extension/src/background/actionHandlers.ts
+++ b/packages/extension/src/background/actionHandlers.ts
@@ -56,6 +56,12 @@ export const handleActionApproval = async (
       try {
         const txHash = await accountDeployAction(action, background)
 
+        analytics.track("deployAccount", {
+          status: "success",
+          trigger: "sign",
+          networkId: action.payload.networkId,
+        })
+
         return {
           type: "DEPLOY_ACCOUNT_ACTION_SUBMITTED",
           data: { txHash, actionHash },
@@ -65,6 +71,12 @@ export const handleActionApproval = async (
         if (error.includes("403")) {
           error = `${error}\n\nA 403 error means there's already something running on the selected port. On macOS, AirPlay is using port 5000 by default, so please try running your node on another port and changing the port in Argent X settings.`
         }
+
+        analytics.track("deployAccount", {
+          status: "failure",
+          networkId: action.payload.networkId,
+          errorMessage: `${error}`,
+        })
 
         return {
           type: "DEPLOY_ACCOUNT_ACTION_FAILED",

--- a/packages/extension/src/background/transactions/transactionMessaging.ts
+++ b/packages/extension/src/background/transactions/transactionMessaging.ts
@@ -1,6 +1,7 @@
 import { Account, number, stark } from "starknet"
 
 import { TransactionMessage } from "../../shared/messages/TransactionMessage"
+import { isAccountDeployed } from "../accountDeploy"
 import { HandleMessage, UnhandledMessage } from "../background"
 import { calculateEstimateFeeFromL1Gas } from "./transactionExecution"
 
@@ -32,7 +33,13 @@ export const handleTransactionMessage: HandleMessage<
           accountDeploymentFee: string | undefined,
           maxADFee: string | undefined
 
-        if (selectedAccount.needsDeploy) {
+        if (
+          selectedAccount.needsDeploy &&
+          !(await isAccountDeployed(
+            selectedAccount,
+            starknetAccount.getClassAt,
+          ))
+        ) {
           const { overall_fee: adFee, suggestedMaxFee: suggestedADFee } =
             await wallet.getAccountDeploymentFee(selectedAccount)
 

--- a/packages/extension/src/shared/analytics.ts
+++ b/packages/extension/src/shared/analytics.ts
@@ -56,6 +56,7 @@ export interface Events {
   deployAccount:
     | {
         status: "success"
+        trigger: "sign" | "transaction"
         networkId: string
       }
     | {


### PR DESCRIPTION
Fixes 2 issues:
- is unavailable for deployment error from sequencer in case a wallet is already deployed
- tracking of `deployAccount`