### PR TITLE
fix(dev): fix jsx error on ui build

### DIFF
--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -6,10 +6,10 @@ import dts from "vite-plugin-dts"
 
 export default defineConfig({
   plugins: [
-    react(),
     dts({
       insertTypesEntry: true,
     }),
+    react(),
   ],
   build: {
     lib: {


### PR DESCRIPTION
Fixes an error seemingly introduced by recent deps updates when building the `ui` package: `error TS2305: Module '"react/jsx-runtime"' has no exported member 'jsx'` 