### PR TITLE
BLO-605 - feat(ui): opt-in scroll restoration

### DIFF
--- a/packages/extension/src/ui/features/accounts/AccountContainer.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountContainer.tsx
@@ -1,9 +1,13 @@
-import { ScrollContainer, Tab, TabBar, icons, useScroll } from "@argent/ui"
+import {
+  ScrollContainer,
+  Tab,
+  TabBar,
+  icons,
+  useScrollRestoration,
+} from "@argent/ui"
 import { FC, PropsWithChildren } from "react"
 import { NavLink } from "react-router-dom"
-import styled, { css } from "styled-components"
 
-import { Header } from "../../components/Header"
 import { routes } from "../../routes"
 import { AccountNavigationBar } from "./AccountNavigationBar"
 import { useSelectedAccount } from "./accounts.state"
@@ -11,31 +15,17 @@ import { useAccountTransactions } from "./accountTransactions.state"
 
 const { WalletIcon, NftIcon, ActivityIcon } = icons
 
-export const DeprecatedContainer = styled.div<{
-  header?: boolean
-  footer?: boolean
-}>`
-  ${({ header = false }) =>
-    header &&
-    css`
-      padding-top: 68px;
-    `}
-  ${({ footer = false }) =>
-    footer &&
-    css`
-      padding-bottom: 64px;
-    `}
+export interface AccountContainerProps extends PropsWithChildren {
+  scrollKey: string
+}
 
-  ${Header} > a {
-    width: 36px;
-    height: 36px;
-  }
-`
-
-export const AccountContainer: FC<PropsWithChildren> = ({ children }) => {
+export const AccountContainer: FC<AccountContainerProps> = ({
+  scrollKey,
+  children,
+}) => {
   const account = useSelectedAccount()
   const { pendingTransactions } = useAccountTransactions(account)
-  const { scrollRef, scroll } = useScroll()
+  const { scrollRef, scroll } = useScrollRestoration(scrollKey)
 
   if (!account) {
     return <></>

--- a/packages/extension/src/ui/features/accounts/AccountScreen.tsx
+++ b/packages/extension/src/ui/features/accounts/AccountScreen.tsx
@@ -29,6 +29,7 @@ export const AccountScreen: FC<AccountScreenProps> = ({ tab }) => {
   const showEmpty = !hasAcccount || (hasAcccount && isDeploying)
 
   let body: ReactNode
+  let scrollKey = "accounts/AccountScreen"
   if (showEmpty) {
     return (
       <AccountScreenEmpty onAddAccount={addAccount} isDeploying={isDeploying} />
@@ -44,14 +45,17 @@ export const AccountScreen: FC<AccountScreenProps> = ({ tab }) => {
   } else if (shouldShowFullScreenStatusMessage) {
     return <StatusMessageFullScreenContainer />
   } else if (tab === "tokens") {
+    scrollKey = "accounts/AccountTokens"
     body = <AccountTokens account={account} />
   } else if (tab === "collections") {
+    scrollKey = "accounts/AccountCollections"
     body = <AccountCollections account={account} />
   } else if (tab === "activity") {
+    scrollKey = "accounts/AccountActivityContainer"
     body = <AccountActivityContainer account={account} />
   } else {
     assertNever(tab)
   }
 
-  return <AccountContainer>{body}</AccountContainer>
+  return <AccountContainer scrollKey={scrollKey}>{body}</AccountContainer>
 }

--- a/packages/extension/src/ui/features/settings/SettingsScreen.tsx
+++ b/packages/extension/src/ui/features/settings/SettingsScreen.tsx
@@ -91,6 +91,7 @@ export const SettingsScreen: FC = () => {
           <BarCloseButton onClick={() => navigate(routes.accountTokens())} />
         }
         title={"Settings"}
+        scrollKey={"settings/SettingsScreen"}
       >
         <CellStack>
           {account && (

--- a/packages/ui/src/components/NavigationBar.tsx
+++ b/packages/ui/src/components/NavigationBar.tsx
@@ -1,7 +1,7 @@
 import { Button, Fade, Flex, chakra } from "@chakra-ui/react"
 import { ComponentProps, FC, PropsWithChildren, ReactNode } from "react"
 
-import { IScroll, useNavigateBack } from "../hooks"
+import { ScrollProps, useNavigateBack } from "../hooks"
 import { AbsoluteFlex } from "./Absolute"
 import * as icons from "./icons"
 import { H6 } from "./Typography"
@@ -45,7 +45,7 @@ export interface NavigationBarProps extends PropsWithChildren {
   leftButton?: ReactNode
   title?: ReactNode
   rightButton?: ReactNode
-  scroll?: IScroll
+  scroll?: ScrollProps
   scrollContent?: ReactNode
 }
 

--- a/packages/ui/src/components/NavigationContainer.tsx
+++ b/packages/ui/src/components/NavigationContainer.tsx
@@ -1,22 +1,62 @@
 import React, { FC } from "react"
 
 import { useScroll } from "../hooks"
+import { useScrollRestoration } from "../hooks/useScrollRestoration"
 import { NavigationBar, NavigationBarProps } from "./NavigationBar"
 import { ScrollContainer } from "./ScrollContainer"
+
+type BaseNavigationContainerProps = Omit<NavigationBarProps, "scroll">
+
+export interface NavigationContainerProps extends BaseNavigationContainerProps {
+  /** Unique id for persisting scroll position - if provided, scroll position will be restored when navigating 'back' to this component. See {@link useScrollRestoration} */
+  scrollKey?: string
+}
+
+interface ScrollRestorationNavigationContainerProps
+  extends BaseNavigationContainerProps {
+  scrollKey: string
+}
 
 /**
  * Combines {@link NavigationBar} and {@link ScrollContainer} and sets up the scroll interaction between them
  */
 
-export const NavigationContainer: FC<Omit<NavigationBarProps, "scroll">> = ({
-  scrollContent,
+export const NavigationContainer: FC<NavigationContainerProps> = ({
+  scrollKey,
+  ...rest
+}) => {
+  if (scrollKey) {
+    return (
+      <ScrollRestorationNavigationContainer scrollKey={scrollKey} {...rest} />
+    )
+  }
+  return <BaseNavigationContainer {...rest} />
+}
+
+/** No `scrollKey`, no scroll restoration */
+
+const BaseNavigationContainer: FC<BaseNavigationContainerProps> = ({
   children,
   ...rest
 }) => {
   const { scrollRef, scroll } = useScroll()
   return (
     <>
-      <NavigationBar scroll={scroll} {...rest} scrollContent={scrollContent} />
+      <NavigationBar scroll={scroll} {...rest} />
+      <ScrollContainer ref={scrollRef}>{children}</ScrollContainer>
+    </>
+  )
+}
+
+/** With scroll restoration */
+
+const ScrollRestorationNavigationContainer: FC<
+  ScrollRestorationNavigationContainerProps
+> = ({ scrollKey, children, ...rest }) => {
+  const { scrollRef, scroll } = useScrollRestoration(scrollKey)
+  return (
+    <>
+      <NavigationBar scroll={scroll} {...rest} />
       <ScrollContainer ref={scrollRef}>{children}</ScrollContainer>
     </>
   )

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./useNavigateBack"
 export * from "./useOnClickOutside"
 export * from "./useScroll"
-export type { IScroll } from "./useScroll"
+export * from "./useScrollRestoration"
+export type { ScrollProps } from "./useScroll"
 export * from "./useToast"

--- a/packages/ui/src/hooks/useScroll.ts
+++ b/packages/ui/src/hooks/useScroll.ts
@@ -1,8 +1,12 @@
 import { useCallback, useRef, useState } from "react"
 
-export interface IScroll {
+export interface ScrollProps {
   scrollTop: number
   scrollLeft: number
+}
+
+export interface UseScrollProps {
+  onScroll?: (scroll: ScrollProps) => void
 }
 
 /**
@@ -21,20 +25,24 @@ export interface IScroll {
  * ```
  */
 
-export const useScroll = () => {
+export const useScroll = ({ onScroll: onScrollProp }: UseScrollProps = {}) => {
   const ref = useRef<HTMLDivElement | null>(null)
-  const [scroll, setScroll] = useState<IScroll>({
+  const [scroll, setScroll] = useState<ScrollProps>({
     scrollTop: 0,
     scrollLeft: 0,
   })
 
-  const onScroll = useCallback((e: Event) => {
-    if (!e.currentTarget) {
-      return
-    }
-    const { scrollTop, scrollLeft } = e.currentTarget as HTMLDivElement
-    setScroll({ scrollTop, scrollLeft })
-  }, [])
+  const onScroll = useCallback(
+    (e: Event) => {
+      if (!e.currentTarget) {
+        return
+      }
+      const { scrollTop, scrollLeft } = e.currentTarget as HTMLDivElement
+      setScroll({ scrollTop, scrollLeft })
+      onScrollProp && onScrollProp({ scrollTop, scrollLeft })
+    },
+    [onScrollProp],
+  )
 
   const setRef = useCallback(
     (nextRef: HTMLDivElement | null) => {
@@ -51,5 +59,9 @@ export const useScroll = () => {
     [onScroll],
   )
 
-  return { scrollRef: setRef, scroll }
+  return {
+    scrollRef: setRef,
+    useScrollRef: ref,
+    scroll,
+  }
 }

--- a/packages/ui/src/hooks/useScroll.ts
+++ b/packages/ui/src/hooks/useScroll.ts
@@ -53,7 +53,9 @@ export const useScroll = ({ onScroll: onScrollProp }: UseScrollProps = {}) => {
       if (ref?.current) {
         const { scrollTop, scrollLeft } = ref.current
         setScroll({ scrollTop, scrollLeft })
-        ref.current.addEventListener("scroll", onScroll)
+        ref.current.addEventListener("scroll", onScroll, {
+          passive: true,
+        })
       }
     },
     [onScroll],

--- a/packages/ui/src/hooks/useScrollRestoration.ts
+++ b/packages/ui/src/hooks/useScrollRestoration.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect } from "react"
+import { useLayoutEffect } from "react"
 import { NavigationType, useNavigationType } from "react-router-dom"
 
 import { ScrollProps, useScroll } from "./useScroll"
@@ -24,13 +24,7 @@ export const useScrollRestoration = (
   storageKey: string,
   storage: IScrollRestorationStorage | undefined = memoryStorage,
 ): ReturnType<typeof useScroll> => {
-  const onScroll = useCallback(
-    (scroll: ScrollProps) => {
-      storage.set(storageKey, scroll)
-    },
-    [storage, storageKey],
-  )
-  const useScrollProps = useScroll({ onScroll })
+  const useScrollProps = useScroll()
   const navigationType = useNavigationType()
 
   useLayoutEffect(() => {
@@ -39,6 +33,12 @@ export const useScrollRestoration = (
       if (value && useScrollProps.useScrollRef.current) {
         const { scrollTop, scrollLeft } = value
         useScrollProps.useScrollRef.current.scroll(scrollLeft, scrollTop)
+      }
+    }
+    return () => {
+      if (useScrollProps.useScrollRef.current) {
+        const { scrollTop, scrollLeft } = useScrollProps.useScrollRef.current
+        storage.set(storageKey, { scrollTop, scrollLeft })
       }
     }
   }, [navigationType, storage, storageKey, useScrollProps.useScrollRef])

--- a/packages/ui/src/hooks/useScrollRestoration.ts
+++ b/packages/ui/src/hooks/useScrollRestoration.ts
@@ -1,0 +1,47 @@
+import { useCallback, useLayoutEffect } from "react"
+import { NavigationType, useNavigationType } from "react-router-dom"
+
+import { ScrollProps, useScroll } from "./useScroll"
+
+export interface IScrollRestorationStorage {
+  get: (key: string) => ScrollProps | undefined
+  set: (key: string, value: ScrollProps) => void
+}
+
+/** Default store scroll position in volatile memory */
+
+const memoryStorage: IScrollRestorationStorage = new Map<string, ScrollProps>()
+
+/**
+ * Hook providing same functionality as {@link useScroll} but which also restores scroll position
+ *
+ * @param storageKey Unique id for persisting scroll position - if provided, scroll position will be restored when navigating 'back' to this component
+ * @param storage Storage to use, defaults to volatile memory
+ * @returns See {@link useScroll}
+ */
+
+export const useScrollRestoration = (
+  storageKey: string,
+  storage: IScrollRestorationStorage | undefined = memoryStorage,
+): ReturnType<typeof useScroll> => {
+  const onScroll = useCallback(
+    (scroll: ScrollProps) => {
+      storage.set(storageKey, scroll)
+    },
+    [storage, storageKey],
+  )
+  const useScrollProps = useScroll({ onScroll })
+  const navigationType = useNavigationType()
+
+  useLayoutEffect(() => {
+    if (navigationType === NavigationType.Pop) {
+      const value = storage.get(storageKey)
+      if (value && useScrollProps.useScrollRef.current) {
+        const { scrollTop, scrollLeft } = value
+        useScrollProps.useScrollRef.current.scroll(scrollLeft, scrollTop)
+      }
+    }
+  }, [navigationType, storage, storageKey, useScrollProps.useScrollRef])
+
+  return useScrollProps
+}


### PR DESCRIPTION
In preparation for animated transition work, this PR adds opt-in scroll restoration to `NavigationContainer` and a hook for using it independently. To simplify this initial implementation, scroll is restored only on 'pop' (back) navigation.