### PR TITLE
feat: allow the usage of chainId as hex for network switching

### DIFF
--- a/packages/extension/src/background/actionHandlers.ts
+++ b/packages/extension/src/background/actionHandlers.ts
@@ -133,14 +133,12 @@ export const handleActionApproval = async (
       try {
         const networks = await getNetworks()
 
-        const network = networks.find(
-          (n) => n.chainId === action.payload.chainId,
-        )
+        const { chainId } = action.payload
+
+        const network = networks.find((n) => n.chainId === chainId)
 
         if (!network) {
-          throw Error(
-            `Network with chainId ${action.payload.chainId} not found`,
-          )
+          throw Error(`Network with chainId ${chainId} not found`)
         }
 
         const accountsOnNetwork = await getAccounts((account) => {
@@ -148,9 +146,7 @@ export const handleActionApproval = async (
         })
 
         if (!accountsOnNetwork.length) {
-          throw Error(
-            `No accounts found on network with chainId ${action.payload.chainId}`,
-          )
+          throw Error(`No accounts found on network with chainId ${chainId}`)
         }
 
         const currentlySelectedAccount = await wallet.getSelectedAccount()
@@ -166,9 +162,7 @@ export const handleActionApproval = async (
         )
 
         if (!selectedAccount) {
-          throw Error(
-            `No accounts found on network with chainId ${action.payload.chainId}`,
-          )
+          throw Error(`No accounts found on network with chainId ${chainId}`)
         }
 
         return {

--- a/packages/extension/src/background/networkMessaging.ts
+++ b/packages/extension/src/background/networkMessaging.ts
@@ -1,3 +1,5 @@
+import { number, shortString } from "starknet"
+
 import { NetworkMessage } from "../shared/messages/NetworkMessage"
 import { getNetwork, getNetworkByChainId, getNetworks } from "../shared/network"
 import { UnhandledMessage } from "./background"
@@ -67,13 +69,21 @@ export const handleNetworkMessage: HandleMessage<NetworkMessage> = async ({
     }
 
     case "REQUEST_SWITCH_CUSTOM_NETWORK": {
-      const network = await getNetworkByChainId(msg.data.chainId)
+      const { chainId } = msg.data
+
+      const isHexChainId = number.isHex(chainId)
+
+      const decodedChainId = shortString.decodeShortString(chainId)
+
+      const network = await getNetworkByChainId(
+        isHexChainId ? decodedChainId : chainId,
+      )
 
       if (!network) {
         return respond({
           type: "REQUEST_SWITCH_CUSTOM_NETWORK_REJ",
           data: {
-            error: `Network with chainId ${msg.data.chainId} does not exist. Please add the network with wallet_addStarknetChain request`,
+            error: `Network with chainId ${chainId} does not exist. Please add the network with wallet_addStarknetChain request`,
           },
         })
       }


### PR DESCRIPTION
### Issue / feature description

Resolves #1615 

- This feature allows to change network with StarknetChainId enum on starknet.js

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally
