### PR TITLE
fix: update bundlesize for current code size

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "files": [
       {
         "path": "packages/extension/dist/**/*.*",
-        "maxSize": "4mB",
+        "maxSize": "5mB",
         "compression": "none"
       }
     ]


### PR DESCRIPTION
### Issue / feature description

Builds failing due to bundlesize of 4mb

### Changes

- update bundlesize to 5mb

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally
