### PR TITLE
fix: script reproduces exact icon source code

### DIFF
--- a/packages/ui/scripts/generate-icons.ts
+++ b/packages/ui/scripts/generate-icons.ts
@@ -120,8 +120,7 @@ const convertToChakraSvg = (iconComponentCode: string) => {
     "export default SvgComponent",
     "export default chakra(SvgComponent)",
   )
-  return `
-import { chakra } from "@chakra-ui/react"
+  return `import { chakra } from "@chakra-ui/react"
 ${iconComponentCode}`
 }
 
@@ -216,7 +215,7 @@ const generateIconsWithConfig = async (config: IconsConfig) => {
     index++
   }
   lines.push("")
-  const fileContents = lines.join("\r\n")
+  const fileContents = lines.join("\n")
   const indexFileName = path.join(outputFolder, `index.ts`)
   fs.writeFileSync(indexFileName, fileContents, "utf8")
   console.log("Done")


### PR DESCRIPTION
### Issue / feature description

Running the gen:icons script would generate source files with inconsistent white space and line endings, so you would always end up with source code changes - even if the icon artwork is unchanged

### Changes

- remove empty line at beginning of generated file
- use LF instead of old-school CRLF for line endings

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally
