### PR TITLE
chore: Build should be available for each PR as an artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,3 +91,13 @@ jobs:
           name: ${{ env.FILENAME_PREFIX }}-chrome.zip
           path: "*-chrome.zip"
           retention-days: 5
+
+      - name: Set GHA_BRANCH
+        run: echo "GHA_BRANCH=$(echo $GITHUB_REF | awk -F / '{print $3}')" >> $GITHUB_ENV
+      - name: comment PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_REPO: ${{ env.GHA_BRANCH }}
+          INPUT_OWNER: ${{ github.repository_owner }}
+        run: |
+          gh pr comment ${{ env.GHA_BRANCH }} --body "[Builds for local testing](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
         image: shardlabs/starknet-devnet:latest-seed0
         ports:
           - 5050:5050
+    env:
+      FILENAME: argent-extension-${{ github.ref_name }}
 
     steps:
       - name: Check out repository code
@@ -54,5 +56,38 @@ jobs:
             packages/extension/e2e/artifacts/reports/
           retention-days: 5
 
-      - name: Check bundlesize
+      - name: Check bundlesize for chrome
         run: yarn run bundlewatch
+      - name: Set filename prefix
+        run: echo "FILENAME_PREFIX=$(echo ${{ env.FILENAME }}  | tr / -)" >> $GITHUB_ENV
+
+      - name: Create chrome zip
+        run: |
+          cd packages/extension/dist
+          zip -r ${{ env.FILENAME_PREFIX }}-chrome.zip ./*
+          mv ${{ env.FILENAME_PREFIX }}-chrome.zip ../../../
+          cd ../../../
+      - name: Build Firefox version
+        run: MANIFEST_VERSION=v2 yarn --cwd packages/extension build
+      - name: Create firefox zip
+        run: |
+          cd packages/extension/dist
+          zip -r ${{ env.FILENAME_PREFIX }}-firefox.zip ./*
+          mv ${{ env.FILENAME_PREFIX }}-firefox.zip ../../../
+          cd ../../../
+      - name: Check bundlesize for firefox
+        run: yarn run bundlewatch
+      - name: Upload artifacts for firefox
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ${{ env.FILENAME_PREFIX }}-firefox.zip
+          path: "*-firefox.zip"
+          retention-days: 5
+      - name: Upload artifacts for chrome
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ${{ env.FILENAME_PREFIX }}-chrome.zip
+          path: "*-chrome.zip"
+          retention-days: 5


### PR DESCRIPTION
### Team can access a build of the extension in each PR

`Add artifacts download link for each PR using gitHub actions`

### Changes

`changed test gitHub workflow`


### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [ ] Tests updated (if needed)
- [x] All tests are passing locally
<img width="1276" alt="Screenshot 2023-01-25 at 16 51 48" src="https://user-images.githubusercontent.com/45524523/214627212-e5eb7143-8fc8-4bed-826b-178ee28ed5c7.png">

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
