### PR TITLE
BLO-707 fix: token balances are synchronised

### DIFF
--- a/packages/extension/e2e/src/page-objects/Activity.ts
+++ b/packages/extension/e2e/src/page-objects/Activity.ts
@@ -1,0 +1,11 @@
+import { Page, expect } from "@playwright/test"
+
+export default class Activity {
+  constructor(private page: Page) {}
+
+  ensurePendingTransactions(nbr: number) {
+    return expect(
+      this.page.locator(`h6:has-text("Pending transactions${nbr}")`),
+    ).toBeVisible()
+  }
+}

--- a/packages/extension/e2e/src/page-objects/ExtensionPage.ts
+++ b/packages/extension/e2e/src/page-objects/ExtensionPage.ts
@@ -2,6 +2,7 @@ import type { Page } from "@playwright/test"
 
 import Messages from "../utils/Messages"
 import Account from "./Account"
+import Activity from "./Activity"
 import Network from "./Network"
 import Wallet from "./Wallet"
 
@@ -11,6 +12,7 @@ export default class ExtensionPage {
   network: Network
   account: Account
   messages: Messages
+  activity: Activity
   constructor(page: Page, private extensionUrl: string) {
     this.page = page
     this.wallet = new Wallet(page)
@@ -18,6 +20,7 @@ export default class ExtensionPage {
     this.account = new Account(page)
     this.extensionUrl = extensionUrl
     this.messages = new Messages(page)
+    this.activity = new Activity(page)
   }
 
   get settings() {
@@ -40,6 +43,17 @@ export default class ExtensionPage {
     await this.page.goto(this.extensionUrl)
   }
 
+  get activityTab() {
+    return this.page.locator('[aria-label="Activity"]')
+  }
+
+  get pendingTransationsIndicator() {
+    return this.page.locator('[aria-label="Pending transactions"]')
+  }
+
+  get tokens() {
+    return this.page.locator('[aria-label="Tokens"]')
+  }
   async resetExtension() {
     await this.settings.click()
     await this.lockWallet.click()

--- a/packages/extension/e2e/src/specs/sendMaxTokens.spec.ts
+++ b/packages/extension/e2e/src/specs/sendMaxTokens.spec.ts
@@ -24,6 +24,13 @@ test.describe("Send max tokens", () => {
       tokenName: "Ethereum",
       ammount: "MAX",
     })
+    //check activity
+    await extension.pendingTransationsIndicator.click()
+    await extension.activity.ensurePendingTransactions(1)
+    await extension.tokens.click()
+    await expect(extension.pendingTransationsIndicator).not.toBeVisible({
+      timeout: 90000,
+    })
 
     await extension.account.token("Ethereum").click()
     await expect(extension.account.balance).toContainText("0.00")

--- a/packages/extension/e2e/src/test.ts
+++ b/packages/extension/e2e/src/test.ts
@@ -92,7 +92,6 @@ const initBrowserWithExtension = async (testInfo: TestInfo) => {
   })
 
   let page = browserContext.pages()[0]
-  await page.emulateMedia({ reducedMotion: "reduce" })
 
   await page.bringToFront()
   await page.goto("chrome://inspect/#extensions")
@@ -114,6 +113,8 @@ const initBrowserWithExtension = async (testInfo: TestInfo) => {
   if (!page) {
     page = pages[0]
   }
+
+  await page.emulateMedia({ reducedMotion: "reduce" })
 
   return { browserContext, extensionURL, page }
 }

--- a/packages/extension/src/ui/features/accountTokens/TokenListItem.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenListItem.tsx
@@ -1,5 +1,5 @@
 import { Button, FieldError, H6, P4, icons } from "@argent/ui"
-import { Flex, Tooltip } from "@chakra-ui/react"
+import { Flex, Skeleton, Tooltip } from "@chakra-ui/react"
 import { ComponentProps, FC } from "react"
 
 import {
@@ -41,6 +41,9 @@ export const TokenListItem: FC<TokenListItemProps> = ({
   const displayBalance = prettifyTokenBalance(token)
   const displayCurrencyValue = prettifyCurrencyValue(currencyValue)
   const isNoCurrencyVariant = variant === "no-currency"
+  if (token.balance === undefined && !errorMessage) {
+    return <Skeleton height={17} rounded={"xl"} />
+  }
   return (
     <CustomButtonCell {...rest}>
       <TokenIcon size={9} url={image} name={name} />

--- a/packages/extension/src/ui/features/accountTokens/TokenListItemContainer.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenListItemContainer.tsx
@@ -30,8 +30,6 @@ export const TokenListItemContainer: FC<TokenListItemContainerProps> = ({
           true /** using Suspense, causes error to be returned as `balance` instead of throwing */,
       },
       {
-        suspense:
-          true /** Suspense allows us to show an initial loader for all tokens */,
         refreshInterval: 60 * 1000 /** 60 seconds */,
       },
     )

--- a/packages/extension/src/ui/features/accountTokens/TokenListItemContainer.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenListItemContainer.tsx
@@ -1,7 +1,6 @@
 import { FC } from "react"
 
 import { Token } from "../../../shared/token/type"
-import { withPolling } from "../../services/swr"
 import { Account } from "../accounts/Account"
 import { TokenListItem, TokenListItemProps } from "./TokenListItem"
 import { useTokenBalanceToCurrencyValue } from "./tokenPriceHooks"
@@ -33,15 +32,15 @@ export const TokenListItemContainer: FC<TokenListItemContainerProps> = ({
       {
         suspense:
           true /** Suspense allows us to show an initial loader for all tokens */,
-        ...withPolling(60 * 1000) /** 60 seconds */,
+        refreshInterval: 60 * 1000 /** 60 seconds */,
       },
     )
 
   const currencyValue = useTokenBalanceToCurrencyValue(tokenWithBalance)
   const shouldShow =
     token.showAlways ||
-    (tokenWithBalance.balance && tokenWithBalance.balance.gt(0))
-  if (!shouldShow) {
+    (tokenWithBalance?.balance && tokenWithBalance?.balance.gt(0))
+  if (!shouldShow || tokenWithBalance === undefined) {
     return null
   }
   return (

--- a/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
@@ -1,5 +1,5 @@
 import { BarBackButton, NavigationContainer } from "@argent/ui"
-import { FC, useMemo } from "react"
+import { FC } from "react"
 import { Navigate, useNavigate, useParams } from "react-router-dom"
 import styled from "styled-components"
 
@@ -7,6 +7,7 @@ import {
   prettifyCurrencyValue,
   prettifyTokenBalance,
 } from "../../../shared/token/price"
+import { useAppState } from "../../app.state"
 import { Button } from "../../components/Button"
 import { ColumnCenter } from "../../components/Column"
 import { FormatListBulletedIcon } from "../../components/Icons/MuiIcons"
@@ -19,7 +20,8 @@ import { TokenIcon } from "./TokenIcon"
 import { TokenMenuDeprecated } from "./TokenMenuDeprecated"
 import { useTokenBalanceToCurrencyValue } from "./tokenPriceHooks"
 import { toTokenView } from "./tokens.service"
-import { useTokensWithBalance } from "./tokens.state"
+import { useToken } from "./tokens.state"
+import { useTokenBalanceForAccount } from "./useTokenBalanceForAccount"
 
 const TokenScreenWrapper = styled(ColumnCenter)`
   width: 100%;
@@ -79,12 +81,16 @@ export const TokenScreen: FC = () => {
   const navigate = useNavigate()
   const { tokenAddress } = useParams()
   const account = useSelectedAccount()
-  const { tokenDetails, tokenDetailsIsInitialising, isValidating } =
-    useTokensWithBalance(account)
-  const token = useMemo(
-    () => tokenDetails.find(({ address }) => address === tokenAddress),
-    [tokenAddress, tokenDetails],
-  )
+  const { switcherNetworkId } = useAppState()
+  const token = useToken({
+    address: tokenAddress || "0x0",
+    networkId: switcherNetworkId || "Unknown",
+  })
+  const { tokenWithBalance, isValidating } = useTokenBalanceForAccount({
+    token,
+    account,
+  })
+
   const currencyValue = useTokenBalanceToCurrencyValue(token)
   const returnTo = useCurrentPathnameWithQuery()
 
@@ -92,9 +98,10 @@ export const TokenScreen: FC = () => {
     return <Navigate to={routes.accountTokens()} />
   }
 
-  const { address, name, symbol, image } = toTokenView(token)
-  const displayBalance = prettifyTokenBalance(token, false)
-  const isLoading = isValidating || tokenDetailsIsInitialising
+  const { address, name, image, symbol } = toTokenView(token)
+  const displayBalance = tokenWithBalance
+    ? prettifyTokenBalance(tokenWithBalance, false)
+    : "––"
 
   return (
     <NavigationContainer
@@ -110,14 +117,14 @@ export const TokenScreen: FC = () => {
             <TokenIcon name={name} url={image} size={12} />
             <TokenBalanceContainer>
               <LoadingPulse
-                isLoading={isLoading}
+                isLoading={isValidating}
                 display="flex"
-                alignItems="center"
-                gap="2"
+                alignItems="flex-end"
+                gap="1"
               >
                 <H3
                   data-testid={
-                    isLoading ? "tokenBalanceIsLoading" : "tokenBalance"
+                    isValidating ? "tokenBalanceIsLoading" : "tokenBalance"
                   }
                 >
                   {displayBalance}

--- a/packages/extension/src/ui/features/accountTokens/useMaxFeeForTransfer.ts
+++ b/packages/extension/src/ui/features/accountTokens/useMaxFeeForTransfer.ts
@@ -2,6 +2,7 @@ import { BigNumber } from "ethers"
 import { Call, number, stark } from "starknet"
 import useSWR from "swr"
 
+import { getAccountIdentifier } from "../../../shared/wallet.service"
 import { getEstimatedFee } from "../../services/backgroundTransactions"
 import { getUint256CalldataFromBN } from "../../services/transactions"
 import { Account } from "../accounts/Account"
@@ -18,30 +19,21 @@ export const useMaxFeeEstimateForTransfer = (
   error?: any
   loading: boolean
 } => {
-  if (!account || !balance || !tokenAddress) {
-    throw new Error("Account, TokenAddress and Balance are required")
-  }
-
-  const call: Call = {
-    contractAddress: tokenAddress,
-    entrypoint: "transfer",
-    calldata: compileCalldata({
-      recipient: account.address,
-      amount: getUint256CalldataFromBN(balance),
-    }),
-  }
+  const key =
+    account && balance && tokenAddress
+      ? [getAccountIdentifier(account), "maxEthTransferEstimate"]
+      : null
 
   const {
     data: estimatedFee,
     error,
     isValidating,
   } = useSWR(
-    [
-      "maxEthTransferEstimate",
-      Math.floor(Date.now() / 60e3),
-      account.networkId,
-    ],
+    key,
     async () => {
+      if (!account || !balance || !tokenAddress) {
+        return
+      }
       const feeToken = await getNetworkFeeToken(account.networkId)
 
       if (feeToken?.address !== tokenAddress) {
@@ -51,21 +43,29 @@ export const useMaxFeeEstimateForTransfer = (
         }
       }
 
-      return getEstimatedFee(call)
+      const call: Call = {
+        contractAddress: tokenAddress,
+        entrypoint: "transfer",
+        calldata: compileCalldata({
+          recipient: account.address,
+          amount: getUint256CalldataFromBN(balance),
+        }),
+      }
+
+      const estimatedFee = await getEstimatedFee(call)
+      return estimatedFee
     },
     {
-      suspense: false,
-      refreshInterval: 15e3,
-      shouldRetryOnError: false,
+      refreshInterval: 15 * 1000 /** 15 seconds */,
     },
   )
 
   if (error) {
-    return { maxFee: undefined, error, loading: false }
+    return { maxFee: undefined, error, loading: isValidating }
   }
 
   // Add Overhead to estimatedFee
-  if (estimatedFee) {
+  if (estimatedFee && account) {
     const { suggestedMaxFee, maxADFee } = estimatedFee
 
     const totalMaxFee =
@@ -78,7 +78,7 @@ export const useMaxFeeEstimateForTransfer = (
     return {
       maxFee: number.toHex(maxFee),
       error: undefined,
-      loading: false,
+      loading: isValidating,
     }
   }
 

--- a/packages/extension/src/ui/features/accountTokens/useTokenBalanceForAccount.ts
+++ b/packages/extension/src/ui/features/accountTokens/useTokenBalanceForAccount.ts
@@ -15,8 +15,9 @@ import { useAccountTransactions } from "../accounts/accountTransactions.state"
 import { TokenDetailsWithBalance } from "./tokens.state"
 
 interface UseTokenBalanceForAccountArgs {
-  token: Token
-  account: Account
+  /** Not passing valid `token` will return undefined `tokenWithBalance` with descrption in `errorMessage`, this allows for lazy loading */
+  token?: Token
+  account?: Account
   /** Return `data` as {@link TokenBalanceErrorMessage} rather than throwing so the UI can choose if / how to display it to the user without `ErrorBoundary` */
   shouldReturnError?: boolean
 }
@@ -32,14 +33,23 @@ export const useTokenBalanceForAccount = (
 ) => {
   const { pendingTransactions } = useAccountTransactions(account)
   const pendingTransactionsLengthRef = useRef(pendingTransactions.length)
-  const { data, mutate, ...rest } = useSWR<string | TokenBalanceErrorMessage>(
-    [
-      getAccountIdentifier(account),
-      "balanceOf",
-      token.address,
-      token.networkId,
-    ],
+  const key =
+    token && account
+      ? [
+          getAccountIdentifier(account),
+          "balanceOf",
+          token.address,
+          token.networkId,
+        ]
+      : null
+  const { data, mutate, ...rest } = useSWR<
+    string | TokenBalanceErrorMessage | undefined
+  >(
+    key,
     async () => {
+      if (!token || !account) {
+        return
+      }
       try {
         const balance = await getTokenBalanceForAccount(
           token.address,
@@ -71,6 +81,15 @@ export const useTokenBalanceForAccount = (
 
   /** as a convenience, also return the token with balance and error message */
   const { tokenWithBalance, errorMessage } = useMemo(() => {
+    if (!token) {
+      return {
+        tokenWithBalance: undefined,
+        errorMessage: {
+          message: "Error",
+          description: "token is not defined",
+        },
+      }
+    }
     const tokenWithBalance: TokenDetailsWithBalance = {
       ...token,
     }

--- a/packages/extension/src/ui/services/swr.ts
+++ b/packages/extension/src/ui/services/swr.ts
@@ -38,7 +38,11 @@ const swrPersistedCache: Cache = {
   },
 }
 
-/** SWR config - keep default behaviour with refresh and dedepe for 'polling' behaviour */
+/**
+ * SWR config - refresh and dedupe for 'polling' behaviour, useful for polling services
+ * NOTE: enabling deduping will naturally disable revalidation on mount etc.
+ */
+
 export const withPolling = (interval: number) => {
   return {
     refreshInterval: interval,

--- a/packages/ui/src/theme/spacing.ts
+++ b/packages/ui/src/theme/spacing.ts
@@ -19,6 +19,7 @@ export const spacing = {
   12: pxToRem(48),
   14: pxToRem(56),
   16: pxToRem(64),
+  17: pxToRem(68),
   18: pxToRem(72),
   24: pxToRem(96),
 }


### PR DESCRIPTION
### Issue / feature description

Token balances are not synchronised across screens and may sometimes show outdated values

### Changes

- use single balanceOf swr hook for individual token balances to share cached value
- use refreshInterval instead of polling helper so values are revalidated on mount
- use inline 'skeleton' loading state for initial token balances

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

