### PR TITLE
fix: allow version and nonce as hex

### DIFF
--- a/packages/guardian/src/services/GuardianSigner.ts
+++ b/packages/guardian/src/services/GuardianSigner.ts
@@ -61,11 +61,11 @@ export class GuardianSigner extends Signer {
 
     const cosignerMessage = {
       contractAddress: addAddressPadding(transactionsDetail.walletAddress),
-      version: transactionsDetail.version.toString(10),
+      version: number.toBN(transactionsDetail.version).toString(10),
       calldata: calldata.map((data) => number.toHex(number.toBN(data))),
       maxFee: number.toBN(transactionsDetail.maxFee).toString(10),
       chainId: number.toBN(transactionsDetail.chainId).toString(10),
-      nonce: transactionsDetail.nonce.toString(10),
+      nonce: number.toBN(transactionsDetail.nonce).toString(10),
     }
 
     const cosignerSignature = await this.cosignMessage({


### PR DESCRIPTION
### Issue / feature description

Tx simulation sends version and nonce as hex which don't get converted in current code

### Changes

- convert to BN before converting to decimal

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally
