### PR TITLE
[BLO-715] Extension bricked after restoring from recovery phrase with no deployed accounts

### DIFF
--- a/packages/extension/src/background/wallet.ts
+++ b/packages/extension/src/background/wallet.ts
@@ -309,6 +309,9 @@ export class Wallet {
         accounts,
         accountDetailFetchers,
       )
+      if (accountsWithDetails.length === 0) {
+        throw new Error("No account found")
+      }
       return accountsWithDetails
     } catch (error) {
       console.error(


### PR DESCRIPTION
### Issue / feature description

Follow up of the previous PR applied to a particular issue: no account found but the user is allowed to progress through the onboarding flow.
