### PR TITLE
[BLO-664] Apply estimated maxFee when sending a transaction

### DIFF
--- a/packages/extension/src/background/transactions/fees/store.ts
+++ b/packages/extension/src/background/transactions/fees/store.ts
@@ -23,7 +23,6 @@ export const estimatedFeesStore = new ArrayStorage<EstimatedFeesEnriched>([], {
 const timestampInSeconds = (): number => Math.floor(Date.now() / 1000)
 
 export const addEstimatedFees = (estimatedFees: EstimatedFees) => {
-  console.log("calling addesimtated", estimatedFees)
   const newEstimatedFees = {
     ...estimatedFees,
     timestamp: timestampInSeconds(),

--- a/packages/extension/src/background/transactions/fees/store.ts
+++ b/packages/extension/src/background/transactions/fees/store.ts
@@ -1,0 +1,50 @@
+import { isEqual } from "lodash-es"
+import { Call } from "starknet5"
+
+import { ArrayStorage } from "../../../shared/storage"
+
+type EstimatedFees = {
+  amount: string
+  suggestedMaxFee: string
+  accountDeploymentFee?: string
+  maxADFee?: string
+  transactions: Call | Call[]
+}
+
+type EstimatedFeesEnriched = EstimatedFees & {
+  timestamp: number
+}
+
+export const estimatedFeesStore = new ArrayStorage<EstimatedFeesEnriched>([], {
+  namespace: "core:estimatedFees",
+  areaName: "local",
+})
+
+const timestampInSeconds = (): number => Math.floor(Date.now() / 1000)
+
+export const addEstimatedFees = (estimatedFees: EstimatedFees) => {
+  console.log("calling addesimtated", estimatedFees)
+  const newEstimatedFees = {
+    ...estimatedFees,
+    timestamp: timestampInSeconds(),
+  }
+  return estimatedFeesStore.push(newEstimatedFees)
+}
+
+export const getEstimatedFees = async (
+  transactions: Call | Call[],
+): Promise<EstimatedFeesEnriched | null> => {
+  const fees = await estimatedFeesStore.get((value) =>
+    isEqual(value.transactions, transactions),
+  )
+  const FIFTEEN_SECONDS = 15
+  const feesExist = fees.length > 0
+  const areFeesOutdated =
+    feesExist &&
+    fees[0].timestamp + FIFTEEN_SECONDS < Math.floor(Date.now() / 1000)
+
+  if (feesExist && !areFeesOutdated) {
+    return fees[0]
+  }
+  return null
+}

--- a/packages/extension/src/background/transactions/fees/store.ts
+++ b/packages/extension/src/background/transactions/fees/store.ts
@@ -17,7 +17,7 @@ type EstimatedFeesEnriched = EstimatedFees & {
 
 export const estimatedFeesStore = new ArrayStorage<EstimatedFeesEnriched>([], {
   namespace: "core:estimatedFees",
-  areaName: "local",
+  areaName: "session",
 })
 
 const timestampInSeconds = (): number => Math.floor(Date.now() / 1000)

--- a/packages/extension/src/background/transactions/transactionExecution.ts
+++ b/packages/extension/src/background/transactions/transactionExecution.ts
@@ -22,6 +22,7 @@ import { analytics } from "../analytics"
 import { BackgroundService } from "../background"
 import { getNonce, increaseStoredNonce, resetStoredNonce } from "../nonce"
 import { argentMaxFee } from "../utils/argentMaxFee"
+import { getEstimatedFees } from "./fees/store"
 import { addTransaction, transactionsStore } from "./store"
 
 export const checkTransactionHash = (
@@ -52,6 +53,11 @@ export const executeTransactionAction = async (
 ) => {
   const { transactions, abis, transactionsDetail, meta = {} } = action.payload
   const allTransactions = await transactionsStore.get()
+  const preComputedFees = await getEstimatedFees(transactions)
+
+  analytics.track("executeTransaction", {
+    usesCachedFees: Boolean(preComputedFees),
+  })
 
   if (!(await wallet.isSessionOpen())) {
     throw Error("you need an open session")
@@ -85,14 +91,14 @@ export const executeTransactionAction = async (
     ? number.toHex(number.toBN(transactionsDetail?.nonce || 0))
     : await getNonce(selectedAccount, wallet)
 
-  let maxFee = "0"
-  let maxADFee = "0"
+  let maxFee = preComputedFees?.suggestedMaxFee ?? "0"
+  let maxADFee = preComputedFees?.maxADFee ?? "0"
 
   if (
     selectedAccount.needsDeploy &&
     !(await isAccountDeployed(selectedAccount, starknetAccount.getClassAt))
   ) {
-    if ("estimateFeeBulk" in starknetAccount) {
+    if ("estimateFeeBulk" in starknetAccount && !preComputedFees) {
       const bulkTransactions: TransactionBulk = [
         {
           type: "DEPLOY_ACCOUNT",
@@ -137,7 +143,7 @@ export const executeTransactionAction = async (
       },
     })
   } else {
-    if (hasUpgradePending) {
+    if (hasUpgradePending && !preComputedFees) {
       const oldStarknetAccount = await wallet.getStarknetAccount(
         selectedAccount,
         false,
@@ -147,11 +153,12 @@ export const executeTransactionAction = async (
         transactions,
       )
       maxFee = argentMaxFee(suggestedMaxFee)
-    } else {
+    } else if (!preComputedFees) {
       // estimate fee with onchain nonce even tho transaction nonce may be different
       const { suggestedMaxFee } = await starknetAccount.estimateFee(
         transactions,
       )
+
       maxFee = argentMaxFee(suggestedMaxFee)
     }
   }

--- a/packages/extension/src/background/transactions/transactionExecution.ts
+++ b/packages/extension/src/background/transactions/transactionExecution.ts
@@ -98,7 +98,7 @@ export const executeTransactionAction = async (
     selectedAccount.needsDeploy &&
     !(await isAccountDeployed(selectedAccount, starknetAccount.getClassAt))
   ) {
-    if ("estimateFeeBulk" in starknetAccount && !preComputedFees) {
+    if ("estimateFeeBulk" in starknetAccount) {
       const bulkTransactions: TransactionBulk = [
         {
           type: "DEPLOY_ACCOUNT",
@@ -113,8 +113,12 @@ export const executeTransactionAction = async (
         bulkTransactions,
       )
 
-      maxADFee = argentMaxFee(estimateFeeBulk[0].suggestedMaxFee)
-      maxFee = argentMaxFee(estimateFeeBulk[1].suggestedMaxFee)
+      maxADFee =
+        preComputedFees?.maxADFee ??
+        argentMaxFee(estimateFeeBulk[0].suggestedMaxFee)
+      maxFee =
+        preComputedFees?.suggestedMaxFee ??
+        argentMaxFee(estimateFeeBulk[1].suggestedMaxFee)
     }
     const { account, txHash } = await wallet.deployAccount(selectedAccount, {
       maxFee: maxADFee,
@@ -143,7 +147,7 @@ export const executeTransactionAction = async (
       },
     })
   } else {
-    if (hasUpgradePending && !preComputedFees) {
+    if (hasUpgradePending && !preComputedFees?.suggestedMaxFee) {
       const oldStarknetAccount = await wallet.getStarknetAccount(
         selectedAccount,
         false,
@@ -153,7 +157,7 @@ export const executeTransactionAction = async (
         transactions,
       )
       maxFee = argentMaxFee(suggestedMaxFee)
-    } else if (!preComputedFees) {
+    } else if (!preComputedFees?.suggestedMaxFee) {
       // estimate fee with onchain nonce even tho transaction nonce may be different
       const { suggestedMaxFee } = await starknetAccount.estimateFee(
         transactions,

--- a/packages/extension/src/background/transactions/transactionMessaging.ts
+++ b/packages/extension/src/background/transactions/transactionMessaging.ts
@@ -4,7 +4,7 @@ import { TransactionMessage } from "../../shared/messages/TransactionMessage"
 import { isAccountDeployed } from "../accountDeploy"
 import { HandleMessage, UnhandledMessage } from "../background"
 import { argentMaxFee } from "../utils/argentMaxFee"
-import { addEstimatedFees, getEstimatedFees } from "./fees/store"
+import { addEstimatedFees } from "./fees/store"
 
 export const handleTransactionMessage: HandleMessage<
   TransactionMessage
@@ -25,14 +25,7 @@ export const handleTransactionMessage: HandleMessage<
       const selectedAccount = await wallet.getSelectedAccount()
       const starknetAccount = await wallet.getSelectedStarknetAccount()
       const transactions = msg.data
-      const preComputedFees = await getEstimatedFees(transactions)
 
-      if (preComputedFees) {
-        return respond({
-          type: "ESTIMATE_TRANSACTION_FEE_RES",
-          data: preComputedFees,
-        })
-      }
       if (!selectedAccount) {
         throw Error("no accounts")
       }

--- a/packages/extension/src/shared/analytics.ts
+++ b/packages/extension/src/shared/analytics.ts
@@ -98,6 +98,9 @@ export interface Events {
     networkId: string
     pair: string
   }
+  executeTransaction: {
+    usesCachedFees: boolean
+  }
 }
 
 export interface Pages {


### PR DESCRIPTION
### Issue / feature description

`We are basically memoizing the fee computation so that the same fee is applied in the estimate screen and in the transaction execution itself`


