### PR TITLE
[BLO-729] Activity view should display fee cost

### DIFF
--- a/packages/extension/src/ui/features/accountActivity/AccountActivity.tsx
+++ b/packages/extension/src/ui/features/accountActivity/AccountActivity.tsx
@@ -49,6 +49,7 @@ export const AccountActivity: FC<AccountActivityProps> = ({
                 return (
                   <TransactionListItem
                     key={hash}
+                    txHash={hash}
                     transactionTransformed={transactionTransformed}
                     network={account.network}
                     onClick={() => navigate(routes.transactionDetail(hash))}
@@ -77,6 +78,7 @@ export const AccountActivity: FC<AccountActivityProps> = ({
                 return (
                   <Fragment key={transactionHash}>
                     <TransactionListItem
+                      txHash={transactionHash}
                       transactionTransformed={explorerTransactionTransformed}
                       network={account.network}
                       onClick={() =>

--- a/packages/extension/src/ui/features/accountActivity/PendingTransactions.tsx
+++ b/packages/extension/src/ui/features/accountActivity/PendingTransactions.tsx
@@ -82,6 +82,7 @@ export const PendingTransactions: FC<PendingTransactionsProps> = ({
           return (
             <TransactionListItem
               key={hash}
+              txHash={hash}
               transactionTransformed={transactionTransformed}
               network={network}
               onClick={() => openBlockExplorerTransaction(hash, network)}

--- a/packages/extension/src/ui/features/accountActivity/TransactionDetail.tsx
+++ b/packages/extension/src/ui/features/accountActivity/TransactionDetail.tsx
@@ -52,6 +52,7 @@ import { NFTTitle } from "./ui/NFTTitle"
 import { TransactionCallDataBottomSheet } from "./ui/TransactionCallDataBottomSheet"
 import { TransactionIcon } from "./ui/TransactionIcon"
 import { TransferTitle } from "./ui/TransferTitle"
+import { useTransactionFees } from "./useTransactionFees"
 
 const { ActivityIcon } = icons
 
@@ -159,8 +160,14 @@ export const TransactionDetail: FC<TransactionDetailProps> = ({
   network,
   tokensByNetwork,
 }) => {
+  const hash = explorerTransaction?.transactionHash || transaction?.hash
+  const txFee = useTransactionFees({
+    hash,
+    transactionTransformed,
+    network,
+  })
   const [bottomSheetOpen, setBottomSheetOpen] = useState(false)
-  const { action, date, displayName, actualFee, dapp } = transactionTransformed
+  const { action, date, displayName, dapp } = transactionTransformed
   const isRejected =
     explorerTransaction?.status === "REJECTED" ||
     transaction?.status === "REJECTED"
@@ -263,13 +270,13 @@ export const TransactionDetail: FC<TransactionDetailProps> = ({
   const displayContractAddress =
     !!explorerTransaction &&
     formatTruncatedAddress(explorerTransaction.contractAddress)
-  const hash = explorerTransaction?.transactionHash || transaction?.hash
   const displayTransactionHash = !!hash && formatTruncatedAddress(hash)
   const calls = explorerTransaction?.calls || transaction?.meta?.transactions
   const errorMessage =
     isRejected &&
     transaction &&
     getErrorMessageFromErrorDump(transaction.failureReason?.error_message)
+
   return (
     <StyledTransactionDetailWrapper
       scrollContent={transactionTransformed.displayName || "Transaction"}
@@ -396,7 +403,7 @@ export const TransactionDetail: FC<TransactionDetailProps> = ({
         )}
         {dapp && <DappContractField knownContract={dapp} />}
         {additionalFields}
-        {actualFee && <FeeField fee={actualFee} networkId={network.id} />}
+        {txFee && <FeeField fee={txFee} networkId={network.id} />}
       </FieldGroup>
       {isRejected && transaction && (
         <FieldGroup>

--- a/packages/extension/src/ui/features/accountActivity/TransactionListItem.tsx
+++ b/packages/extension/src/ui/features/accountActivity/TransactionListItem.tsx
@@ -28,6 +28,7 @@ export interface TransactionListItemProps {
   highlighted?: boolean
   onClick?: () => void
   children?: ReactNode | ReactNode[]
+  txHash: string
 }
 
 export const TransactionListItem: FC<TransactionListItemProps> = ({
@@ -35,6 +36,7 @@ export const TransactionListItem: FC<TransactionListItemProps> = ({
   network,
   highlighted,
   children,
+  txHash,
   ...props
 }) => {
   const { action, displayName, dapp } = transactionTransformed

--- a/packages/extension/src/ui/features/accountActivity/useTransactionFees.test.ts
+++ b/packages/extension/src/ui/features/accountActivity/useTransactionFees.test.ts
@@ -1,0 +1,42 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, test, vi } from "vitest"
+
+import { Network } from "../../../shared/network"
+import { TransformedTransaction } from "./transform/type"
+import { useTransactionFees } from "./useTransactionFees"
+
+describe("useTransactionFees", () => {
+  vi.mock("../../../shared/network", () => ({
+    getProvider: vi.fn(() => {
+      return {
+        getTransactionReceipt: vi.fn(() => {
+          return {
+            actual_fee: "0",
+          }
+        }),
+      }
+    }),
+  }))
+  test("it should return backend enriched data when available ", async () => {
+    const payload = {
+      network: {} as Network,
+      transactionTransformed: {
+        actualFee: "1",
+      } as TransformedTransaction,
+      hash: undefined,
+    }
+    const { result } = renderHook(() => useTransactionFees(payload))
+    await waitFor(() => expect(result?.current).toBe("1"))
+  })
+  test("it should fallback to starknetjs data if backend data does not exist ", async () => {
+    const payload = {
+      network: {} as Network,
+      transactionTransformed: {
+        actualFee: undefined,
+      } as TransformedTransaction,
+      hash: undefined,
+    }
+    const { result } = renderHook(() => useTransactionFees(payload))
+    await waitFor(() => expect(result?.current).toBe("0"))
+  })
+})

--- a/packages/extension/src/ui/features/accountActivity/useTransactionFees.ts
+++ b/packages/extension/src/ui/features/accountActivity/useTransactionFees.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react"
+
+import { Network, getProvider } from "../../../shared/network"
+import { TransformedTransaction } from "./transform/type"
+
+export const useTransactionFees = ({
+  network,
+  transactionTransformed,
+  hash,
+}: {
+  network: Network
+  transactionTransformed: TransformedTransaction
+  hash?: string
+}) => {
+  const [txFee, setTxFee] = useState<string | undefined>()
+  useEffect(() => {
+    const getFeeFromStarknetJs = async () => {
+      const receipt = await getProvider(network).getTransactionReceipt(hash)
+      setTxFee(transactionTransformed.actualFee ?? receipt.actual_fee)
+    }
+    getFeeFromStarknetJs()
+  }, [hash, network, transactionTransformed.actualFee])
+  return txFee
+}

--- a/packages/extension/src/ui/features/accountActivity/useTransactionFees.ts
+++ b/packages/extension/src/ui/features/accountActivity/useTransactionFees.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import useSWR from "swr"
 
 import { Network, getProvider } from "../../../shared/network"
 import { TransformedTransaction } from "./transform/type"
@@ -12,13 +12,15 @@ export const useTransactionFees = ({
   transactionTransformed: TransformedTransaction
   hash?: string
 }) => {
-  const [txFee, setTxFee] = useState<string | undefined>()
-  useEffect(() => {
-    const getFeeFromStarknetJs = async () => {
-      const receipt = await getProvider(network).getTransactionReceipt(hash)
-      setTxFee(transactionTransformed.actualFee ?? receipt.actual_fee)
-    }
-    getFeeFromStarknetJs()
-  }, [hash, network, transactionTransformed.actualFee])
+  const getFeeFromStarknetJs = async () => {
+    const receipt = await getProvider(network).getTransactionReceipt(hash)
+    return transactionTransformed.actualFee ?? receipt.actual_fee
+  }
+
+  const { data: txFee } = useSWR(
+    [hash, network, transactionTransformed.actualFee],
+    getFeeFromStarknetJs,
+  )
+
   return txFee
 }


### PR DESCRIPTION
### Issue / feature description

`There were already network fees but they were purely relying on backend data. Now there's a fallback with starknet js that way the fees should always be visible for a completed transaction`

### Changes

Added a custom hook to get the fees + test on it

![image](https://user-images.githubusercontent.com/46749544/217822809-e3c458f9-e6e9-4c3d-bac2-20cd5e5d93fb.png)

