### PR TITLE
[BLO-766] Move 2FA <-> backend requests into background process

### DIFF
--- a/packages/extension/src/background/shieldMessaging.ts
+++ b/packages/extension/src/background/shieldMessaging.ts
@@ -6,10 +6,10 @@ import {
   getNetworkSelector,
   withGuardianSelector,
 } from "../shared/account/selectors"
+import { getAccounts } from "../shared/account/store"
 import { ShieldMessage } from "../shared/messages/ShieldMessage"
 import {
   addBackendAccount,
-  getAccounts,
   getBackendAccounts,
   register,
   requestEmailAuthentication,
@@ -134,25 +134,26 @@ export const handleShieldMessage: HandleMessage<ShieldMessage> = async ({
         })
       }
     }
-    case "SHIELD_CONFIRM_EMAIL": {
-      const code = msg.data
-      try {
-        const { userRegistrationStatus } = await verifyEmail(code)
+    case "SHIELD_CONFIRM_EMAIL":
+      {
+        const code = msg.data
+        try {
+          const { userRegistrationStatus } = await verifyEmail(code)
 
-        if (userRegistrationStatus === "notRegistered") {
-          await register()
+          if (userRegistrationStatus === "notRegistered") {
+            await register()
+          }
+          return sendMessageToUi({
+            type: "SHIELD_CONFIRM_EMAIL_RES",
+          })
+        } catch (e) {
+          return sendMessageToUi({
+            type: "SHIELD_CONFIRM_EMAIL_REJ",
+            data: JSON.stringify(e),
+          })
         }
-        return sendMessageToUi({
-          type: "SHIELD_CONFIRM_EMAIL_RES",
-        })
-      } catch (error) {
-        return sendMessageToUi({
-          type: "SHIELD_CONFIRM_EMAIL_REJ",
-          data: `${error}`,
-        })
       }
-    }
-  }
 
-  throw new UnhandledMessage()
+      throw new UnhandledMessage()
+  }
 }

--- a/packages/extension/src/shared/messages/ShieldMessage.ts
+++ b/packages/extension/src/shared/messages/ShieldMessage.ts
@@ -5,3 +5,13 @@ export type ShieldMessage =
       data: { guardianAddress: string }
     }
   | { type: "SHIELD_VALIDATE_ACCOUNT_REJ"; data: string }
+  | { type: "SHIELD_REQUEST_EMAIL"; data: string }
+  | {
+      type: "SHIELD_REQUEST_EMAIL_RES"
+    }
+  | { type: "SHIELD_REQUEST_EMAIL_REJ"; data: string }
+  | { type: "SHIELD_CONFIRM_EMAIL"; data: string }
+  | {
+      type: "SHIELD_CONFIRM_EMAIL_RES"
+    }
+  | { type: "SHIELD_CONFIRM_EMAIL_REJ"; data: string }

--- a/packages/extension/src/shared/shield/backend/account.ts
+++ b/packages/extension/src/shared/shield/backend/account.ts
@@ -4,6 +4,7 @@ import {
   CosignerOffchainMessage,
 } from "@argent/guardian"
 import retry from "async-retry"
+import { z } from "zod"
 
 import { ARGENT_API_BASE_URL } from "../../api/constants"
 import { isFetcherError } from "../../api/fetcher"
@@ -33,12 +34,27 @@ export const requestEmailAuthentication = async (
   }
 }
 
-export type EmailVerificationStatus =
-  | "expired"
-  | "maxAttemptsReached"
-  | "unverified"
-  | "verified"
-  | "notRequested"
+const emailVerificationStatus = [
+  "expired",
+  "maxAttemptsReached",
+  "unverified",
+  "verified",
+  "notRequested",
+] as const
+
+export type EmailVerificationStatus = (typeof emailVerificationStatus)[number]
+
+export const emailVerificationStatusErrorSchema = z.object({
+  name: z.string(),
+  url: z.string().nullable(),
+  status: z.number(),
+  statusText: z.string(),
+  responseText: z.string(),
+  responseJson: z.object({
+    status: z.enum(emailVerificationStatus),
+  }),
+})
+
 export const getEmailVerificationStatus =
   async (): Promise<EmailVerificationStatus> => {
     try {

--- a/packages/extension/src/shared/shield/register.ts
+++ b/packages/extension/src/shared/shield/register.ts
@@ -1,17 +1,27 @@
-import {
-  register,
-  requestEmailAuthentication,
-  verifyEmail,
-} from "./backend/account"
+import { sendMessage, waitForMessage } from "../messages"
 
 export const requestEmail = async (email: string) => {
-  return requestEmailAuthentication(email)
+  sendMessage({ type: "SHIELD_REQUEST_EMAIL", data: email })
+
+  const result = await Promise.race([
+    waitForMessage("SHIELD_REQUEST_EMAIL_RES"),
+    waitForMessage("SHIELD_REQUEST_EMAIL_REJ").then((error) => {
+      throw new Error(error)
+    }),
+  ])
+
+  return result
 }
 
 export const confirmEmail = async (code: string) => {
-  const { userRegistrationStatus } = await verifyEmail(code)
+  sendMessage({ type: "SHIELD_CONFIRM_EMAIL", data: code })
 
-  if (userRegistrationStatus === "notRegistered") {
-    await register()
-  }
+  const result = await Promise.race([
+    waitForMessage("SHIELD_CONFIRM_EMAIL_RES"),
+    waitForMessage("SHIELD_CONFIRM_EMAIL_REJ").then((error) => {
+      throw new Error(error)
+    }),
+  ])
+
+  return result
 }


### PR DESCRIPTION
### Issue / feature description

`Move requests from the UI to the background process.`

### Changes

- Create a few new messages to pass the data around
- Add validation on fetcher error messages so we can safely display custom error messages

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

