### PR TITLE
fix: hot reload server

### DIFF
--- a/packages/extension/scripts/hot-reload-server.ts
+++ b/packages/extension/scripts/hot-reload-server.ts
@@ -1,10 +1,10 @@
 import path from "path"
 
 import chokidar from "chokidar"
-import { debounce } from "lodash-es"
 import WebSocket from "ws"
 
 import { HOT_RELOAD_MESSAGE, HOT_RELOAD_PORT } from "../src/shared/utils/dev"
+import { debounce } from "./utils"
 
 /** watch webpack output changes to trigger reload */
 const watchChangesInPath = path.join(__dirname, "../dist")

--- a/packages/extension/scripts/tsconfig.json
+++ b/packages/extension/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "ts-node/node16/tsconfig.json",
+  "ts-node": {
+    "transpileOnly": true,
+    "files": true
+  }
+}

--- a/packages/extension/scripts/utils.ts
+++ b/packages/extension/scripts/utils.ts
@@ -1,0 +1,13 @@
+/** write a debounce function in TypeScript */
+
+export function debounce<T extends (...args: any[]) => any>(
+  func: T,
+  wait: number,
+): (...args: Parameters<T>) => void {
+  let timeout: NodeJS.Timeout
+
+  return (...args: Parameters<T>) => {
+    clearTimeout(timeout)
+    timeout = setTimeout(() => func(...args), wait)
+  }
+}


### PR DESCRIPTION
### Issue / feature description

The hot reload server was using `debounce` from `lodash`. `lodash` is banned and `lodash-es` doesn't work with `ts-node` atm.

### Changes

- have ChatGPT write a debounce function
- remove lodash / lodash-es dependency

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
