### PR TITLE
BLO-739 fix: 2fa state transition

### DIFF
--- a/packages/extension/src/ui/features/accountEdit/AccountEditScreen.tsx
+++ b/packages/extension/src/ui/features/accountEdit/AccountEditScreen.tsx
@@ -104,7 +104,9 @@ export const AccountEditScreen: FC = () => {
 
   const accountSubtitle = pendingChangeGuardian
     ? `${
-        pendingChangeGuardian === ChangeGuardian.ADDING ? "Adding" : "Removing"
+        pendingChangeGuardian.type === ChangeGuardian.ADDING
+          ? "Adding"
+          : "Removing"
       } Argent Shield…`
     : `Two-factor account protection`
 

--- a/packages/extension/src/ui/features/accounts/accountTransactions.state.ts
+++ b/packages/extension/src/ui/features/accounts/accountTransactions.state.ts
@@ -21,10 +21,6 @@ const byAccountSelector = memoize(
   (account) => (account ? getAccountIdentifier(account) : "unknown-account"),
 )
 
-const byHashSelector = memoize(
-  (hash: string) => (transaction: Transaction) => transaction.hash === hash,
-)
-
 export const useAccountTransactions: UseAccountTransactions = (account) => {
   const transactions = useArrayStorage(
     transactionsStore,
@@ -41,9 +37,4 @@ export const useAccountTransactions: UseAccountTransactions = (account) => {
   )
 
   return { transactions, pendingTransactions }
-}
-
-export const useTransactionWithHash = (hash: string) => {
-  const [hit] = useArrayStorage(transactionsStore, byHashSelector(hash))
-  return hit
 }

--- a/packages/extension/src/ui/features/accounts/accountTransactions.state.ts
+++ b/packages/extension/src/ui/features/accounts/accountTransactions.state.ts
@@ -21,6 +21,10 @@ const byAccountSelector = memoize(
   (account) => (account ? getAccountIdentifier(account) : "unknown-account"),
 )
 
+const byHashSelector = memoize(
+  (hash: string) => (transaction: Transaction) => transaction.hash === hash,
+)
+
 export const useAccountTransactions: UseAccountTransactions = (account) => {
   const transactions = useArrayStorage(
     transactionsStore,
@@ -37,4 +41,9 @@ export const useAccountTransactions: UseAccountTransactions = (account) => {
   )
 
   return { transactions, pendingTransactions }
+}
+
+export const useTransactionWithHash = (hash: string) => {
+  const [hit] = useArrayStorage(transactionsStore, byHashSelector(hash))
+  return hit
 }

--- a/packages/extension/src/ui/features/shield/ShieldAccountFinishScreen.tsx
+++ b/packages/extension/src/ui/features/shield/ShieldAccountFinishScreen.tsx
@@ -6,13 +6,13 @@ import {
   useAccountMetadata,
 } from "../accounts/accountMetadata.state"
 import { ShieldBaseFinishScreen } from "./ShieldBaseFinishScreen"
-import { usePendingChangeGuardian } from "./usePendingChangingGuardian"
+import { useLiveAccountGuardianState } from "./usePendingChangingGuardian"
 import { useRouteAccount } from "./useRouteAccount"
 
 export const ShieldAccountFinishScreen: FC = () => {
   const account = useRouteAccount()
   const accountAddress = useRouteAccountAddress()
-  const pendingChangeGuardian = usePendingChangeGuardian(account)
+  const liveAccountGuardianState = useLiveAccountGuardianState(account)
   const { accountNames } = useAccountMetadata()
   const accountName = account
     ? getAccountName(account, accountNames)
@@ -27,7 +27,7 @@ export const ShieldAccountFinishScreen: FC = () => {
   return (
     <ShieldBaseFinishScreen
       accountName={accountName}
-      pendingChangeGuardian={pendingChangeGuardian}
+      liveAccountGuardianState={liveAccountGuardianState}
       guardian={account?.guardian}
       returnRoute={returnRoute}
     />

--- a/packages/extension/src/ui/features/shield/ShieldAccountFinishScreen.tsx
+++ b/packages/extension/src/ui/features/shield/ShieldAccountFinishScreen.tsx
@@ -28,7 +28,6 @@ export const ShieldAccountFinishScreen: FC = () => {
     <ShieldBaseFinishScreen
       accountName={accountName}
       liveAccountGuardianState={liveAccountGuardianState}
-      guardian={account?.guardian}
       returnRoute={returnRoute}
     />
   )

--- a/packages/extension/src/ui/features/shield/ShieldBaseFinishScreen.tsx
+++ b/packages/extension/src/ui/features/shield/ShieldBaseFinishScreen.tsx
@@ -34,18 +34,17 @@ const getShieldHeaderProps = ({
     }
   }
   const { status, type } = liveAccountGuardianState
+  const isAdding = type === ChangeGuardian.ADDING
   if (status === "ERROR") {
     return {
       icon: AlertIcon,
-      title:
-        type === ChangeGuardian.ADDING
-          ? "Adding Argent Shield Failed"
-          : "Removing Argent Shield Failed",
+      title: isAdding
+        ? "Adding Argent Shield Failed"
+        : "Removing Argent Shield Failed",
       subtitle: `${accountName} was not modified because the transaction failed. Please try again later`,
       variant: "danger",
     }
   }
-  const isAdding = type === ChangeGuardian.ADDING
   if (status === "PENDING") {
     return {
       icon: isAdding ? ArgentShieldIcon : ArgentShieldDeactivateIcon,

--- a/packages/extension/src/ui/features/shield/ui/ShieldHeader.tsx
+++ b/packages/extension/src/ui/features/shield/ui/ShieldHeader.tsx
@@ -31,12 +31,12 @@ const variants = {
   },
 }
 
-type Variant = keyof typeof variants
+export type ShieldHeaderVariant = keyof typeof variants
 
-interface ShieldHeaderProps {
+export interface ShieldHeaderProps {
   title: ReactNode
   subtitle?: ReactNode
-  variant?: Variant
+  variant?: ShieldHeaderVariant
   size?: "md" | "lg"
   icon?: ChakraComponent<"svg">
   isLoading?: boolean

--- a/packages/extension/src/ui/features/shield/usePendingChangingGuardian.ts
+++ b/packages/extension/src/ui/features/shield/usePendingChangingGuardian.ts
@@ -68,6 +68,8 @@ export interface LiveAccountGuardianState {
   type: ChangeGuardian
   /** the status of the change */
   status: ReturnType<typeof useTransactionStatus>
+  /** if the account currently has guardian */
+  hasGuardian: boolean
 }
 
 /**
@@ -107,6 +109,7 @@ export const useLiveAccountGuardianState = (
       return {
         type: pendingChangeGuardianType.current,
         status: transactionStatus,
+        hasGuardian,
       }
     }
 
@@ -118,6 +121,7 @@ export const useLiveAccountGuardianState = (
       return {
         type: pendingChangeGuardianType.current,
         status: transactionStatus,
+        hasGuardian,
       }
     }
 
@@ -125,6 +129,7 @@ export const useLiveAccountGuardianState = (
     return {
       type: pendingChangeGuardianType.current,
       status: "PENDING",
+      hasGuardian,
     }
   }, [hasGuardian, transactionStatus])
 }

--- a/packages/extension/src/ui/features/shield/usePendingChangingGuardian.ts
+++ b/packages/extension/src/ui/features/shield/usePendingChangingGuardian.ts
@@ -1,16 +1,19 @@
-import { useMemo } from "react"
-import { constants, number } from "starknet"
+import { useMemo, useRef } from "react"
+import { Call, constants, number } from "starknet"
 
+import { Transaction } from "../../../shared/transactions"
 import { BaseWalletAccount } from "../../../shared/wallet.model"
+import { useAccount } from "../accounts/accounts.state"
 import { useAccountTransactions } from "../accounts/accountTransactions.state"
+import { useTransactionStatus } from "../accountTokens/useTransactionStatus"
 
 export enum ChangeGuardian {
+  /** Guardian is not being changed */
+  NONE = "NONE",
   /** Guardian is being added */
   ADDING = "ADDING",
   /** Guardian is being removed */
   REMOVING = "REMOVING",
-  /** Guardian transaction but unrecognised */
-  UNKNOWN = "UNKNOWN",
 }
 
 /**
@@ -19,9 +22,29 @@ export enum ChangeGuardian {
  * @returns `ChangeGuardian` status if there is a pending transaction, otherwise `undefined`
  */
 
+const callDataToType = (transactions?: Call | Call[]) => {
+  const calldata = Array.isArray(transactions)
+    ? transactions[0].calldata
+    : transactions?.calldata
+  if (calldata?.[0]) {
+    const guardianAddress = number.toBN(calldata[0])
+    if (guardianAddress.eq(constants.ZERO)) {
+      return ChangeGuardian.REMOVING
+    } else {
+      return ChangeGuardian.ADDING
+    }
+  }
+  return ChangeGuardian.NONE
+}
+
+export interface PendingChangeGuardian {
+  transaction: Transaction
+  type: ChangeGuardian
+}
+
 export const usePendingChangeGuardian = (
   account?: BaseWalletAccount,
-): ChangeGuardian | undefined => {
+): PendingChangeGuardian | undefined => {
   const { pendingTransactions } = useAccountTransactions(account)
   const pendingChangeGuardian = useMemo(() => {
     const changeGuardianTransaction = pendingTransactions.find(
@@ -29,25 +52,79 @@ export const usePendingChangeGuardian = (
     )
     if (changeGuardianTransaction) {
       const transactions = changeGuardianTransaction.meta?.transactions
-      const calldata = Array.isArray(transactions)
-        ? transactions[0].calldata
-        : transactions?.calldata
-      if (calldata?.[0]) {
-        const guardianAddress = number.toBN(calldata[0])
-        if (guardianAddress.eq(constants.ZERO)) {
-          return ChangeGuardian.REMOVING
-        } else {
-          return ChangeGuardian.ADDING
-        }
-      } else {
-        console.warn(
-          "Unhandled pending guardian transaction",
-          changeGuardianTransaction,
-        )
-        return ChangeGuardian.UNKNOWN
+      const type = callDataToType(transactions)
+      return {
+        transaction: changeGuardianTransaction,
+        type,
       }
     }
   }, [pendingTransactions])
 
   return pendingChangeGuardian
+}
+
+export interface LiveAccountGuardianState {
+  /** the type of change */
+  type: ChangeGuardian
+  /** the status of the change */
+  status: ReturnType<typeof useTransactionStatus>
+}
+
+/**
+ * Hook to return live pending 'changeGuardian' status for the provided account
+ * When invoked will keep a reference to any pending changeGuardian tx
+ * and return status during its lifecycle, including awaiting for on-chain
+ * state to change before moving to SUCCESS state
+ * @param account - the account to check
+ * @returns `UseLiveAccountGuardianState` status
+ */
+
+export const useLiveAccountGuardianState = (
+  account?: BaseWalletAccount,
+): LiveAccountGuardianState => {
+  const liveAccount = useAccount(account)
+
+  /** keep initial guardian state so we can react to change */
+  const hasGuardian = Boolean(liveAccount?.guardian)
+  const previousHasGuardian = useRef(hasGuardian)
+
+  /** react to the same transaction for our lifecycle */
+  const pendingChangeGuardian = usePendingChangeGuardian(account)
+  const pendingChangeGuardianType = useRef(
+    pendingChangeGuardian?.type || ChangeGuardian.NONE,
+  )
+  const pendingChangeGuardianHash = useRef(
+    pendingChangeGuardian?.transaction.hash || "",
+  )
+  const transactionStatus = useTransactionStatus(
+    pendingChangeGuardianHash.current,
+    account?.networkId,
+  )
+
+  return useMemo(() => {
+    /** Tx failure or none found */
+    if (["ERROR", "UNKNOWN"].includes(transactionStatus)) {
+      return {
+        type: pendingChangeGuardianType.current,
+        status: transactionStatus,
+      }
+    }
+
+    /** Checks if on-chain state changed */
+    const guardianChanged = hasGuardian !== previousHasGuardian.current
+
+    /** Tx success AND guardian state updated on-chain */
+    if (transactionStatus === "SUCCESS" && guardianChanged) {
+      return {
+        type: pendingChangeGuardianType.current,
+        status: transactionStatus,
+      }
+    }
+
+    /** PENDING while awaiting other states */
+    return {
+      type: pendingChangeGuardianType.current,
+      status: "PENDING",
+    }
+  }, [hasGuardian, transactionStatus])
 }


### PR DESCRIPTION
### Issue / feature description

Fixes an issue where the 'live' state of 2FA on account was not in sync with on-chain state and would show momentarily in the wrong state

### Changes

- add a hook to react to both tx and on-chain state, resolving when on-chain state is updated
- also display tx failure

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally