### PR TITLE
BLO-777 feat: 2fa auto-enable shield

### DIFF
--- a/packages/extension/src/ui/App.tsx
+++ b/packages/extension/src/ui/App.tsx
@@ -9,6 +9,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary"
 import { AppDimensions } from "./components/Responsive"
 import { LoadingScreen } from "./features/actions/LoadingScreen"
 import DevUI from "./features/dev/DevUI"
+import { useAutoEnableArgentShield } from "./features/shield/useArgentShieldEnabled"
 import { useCaptureEntryRouteRestorationState } from "./features/stateRestoration/useRestorationState"
 import { useTracking } from "./services/analytics"
 import SoftReloadProvider from "./services/resetAndReload"
@@ -20,6 +21,7 @@ export const App: FC = () => {
   useTracking()
   useSentryInit()
   useCaptureEntryRouteRestorationState()
+  useAutoEnableArgentShield()
   return (
     <SoftReloadProvider>
       <SWRConfig value={{ provider: () => swrCacheProvider }}>

--- a/packages/extension/src/ui/features/shield/useArgentShieldEnabled.ts
+++ b/packages/extension/src/ui/features/shield/useArgentShieldEnabled.ts
@@ -1,6 +1,9 @@
+import { useEffect } from "react"
+
 import { settingsStore } from "../../../shared/settings"
 import { ARGENT_SHIELD_ENABLED } from "../../../shared/shield/constants"
 import { useKeyValueStorage } from "../../../shared/storage/hooks"
+import { useAccountsWithGuardian } from "./useAccountGuardian"
 
 export const useArgentShieldEnabled = () => {
   const privacyUseArgentServices = useKeyValueStorage(
@@ -8,4 +11,26 @@ export const useArgentShieldEnabled = () => {
     "experimentalEnableArgentShield",
   )
   return ARGENT_SHIELD_ENABLED && privacyUseArgentServices
+}
+
+/**
+ * Auto-enable Shield if at least one account has Guardian
+ * TODO: remove when Shield is permanently enabled
+ */
+
+export const useAutoEnableArgentShield = () => {
+  const accountsWithGuardian = useAccountsWithGuardian()
+  const experimentalEnableArgentShield = useKeyValueStorage(
+    settingsStore,
+    "experimentalEnableArgentShield",
+  )
+  useEffect(() => {
+    if (!ARGENT_SHIELD_ENABLED) {
+      /** do nothing */
+      return
+    }
+    if (accountsWithGuardian.length > 0 && !experimentalEnableArgentShield) {
+      settingsStore.set("experimentalEnableArgentShield", true)
+    }
+  }, [accountsWithGuardian.length, experimentalEnableArgentShield])
 }


### PR DESCRIPTION
### Issue / feature description

Users who recover and have accounts with 2FA enabled, we should automatically enable the 2FA feature in settings for them

### Changes

- add a check for accounts with 2FA and enable the 2FA setting if > 0 and setting is not enabled

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally