### PR TITLE
fix: zod schema for aspect nft

### DIFF
--- a/packages/extension/src/ui/features/accountNfts/aspect.model.ts
+++ b/packages/extension/src/ui/features/accountNfts/aspect.model.ts
@@ -28,8 +28,8 @@ export const AspectNftSchema = z.object({
   best_bid_order: z
     .object({
       payment_address: z.string(),
-      payment_amount: z.number().optional(),
-      payment_amount_per: z.number().optional(),
+      payment_amount: z.string().optional(),
+      payment_amount_per: z.string().optional(),
     })
     .optional()
     .nullable(),


### PR DESCRIPTION
### Issue / feature description

Wrong type in zod schema causing NFT screen to crash

### Changes

Changed best_bid_order properties from `number` to `string` (checked also in aspect api response) 

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
