### PR TITLE
fix(firefox): change implementation

### DIFF
--- a/packages/extension/src/shared/messages/index.ts
+++ b/packages/extension/src/shared/messages/index.ts
@@ -31,8 +31,20 @@ export type WindowMessageType = MessageType & {
   extensionId: string
 }
 
-export const [sendMessage, messageStream, _waitForMessage] =
+export const [_sendMessage, messageStream, _waitForMessage] =
   getMessage<MessageType>("ARGENTX")
+
+export function sendMessage<T extends MessageType>(message: T) {
+  // remove all functions from the message object
+  // as they cannot be sent over the message bus (and make firefox crash)
+  const cleanMessage = JSON.parse(
+    JSON.stringify(message, (_, value) =>
+      typeof value === "function" ? undefined : value,
+    ),
+  )
+
+  return _sendMessage(cleanMessage)
+}
 
 export async function waitForMessage<
   K extends MessageType["type"],

--- a/packages/extension/src/shared/messages/index.ts
+++ b/packages/extension/src/shared/messages/index.ts
@@ -1,4 +1,5 @@
 import { getMessage } from "@extend-chrome/messages"
+import type { SendOptions } from "@extend-chrome/messages/types/types"
 
 import { IS_DEV } from "../utils/dev"
 import { AccountMessage } from "./AccountMessage"
@@ -34,16 +35,19 @@ export type WindowMessageType = MessageType & {
 export const [_sendMessage, messageStream, _waitForMessage] =
   getMessage<MessageType>("ARGENTX")
 
-export function sendMessage<T extends MessageType>(message: T) {
+export function sendMessage(
+  data: MessageType,
+  options?: SendOptions | undefined,
+) {
   // remove all functions from the message object
   // as they cannot be sent over the message bus (and make firefox crash)
   const cleanMessage = JSON.parse(
-    JSON.stringify(message, (_, value) =>
+    JSON.stringify(data, (_, value) =>
       typeof value === "function" ? undefined : value,
     ),
   )
 
-  return _sendMessage(cleanMessage)
+  return _sendMessage(cleanMessage, options)
 }
 
 export async function waitForMessage<


### PR DESCRIPTION
Firefox is not able to handle functions in the message bus

Usually we do not send (and never expect) functions, but sometimes it's easier to pass a superset of the message to the function. This PR will make sure that functions in this superset will get ignored