### PR TITLE
[BLO-732] Export private key - Export button always disabled

### DIFF
--- a/packages/extension/src/ui/features/accountTokens/ExportPrivateKeyScreen.tsx
+++ b/packages/extension/src/ui/features/accountTokens/ExportPrivateKeyScreen.tsx
@@ -85,11 +85,9 @@ export const ExportPrivateKeyScreen: FC = () => {
         <Paragraph>Enter your password to export your private key.</Paragraph>
 
         <PasswordForm verifyPassword={handleVerifyPassword}>
-          {({ isDirty, isSubmitting }) => (
+          {() => (
             <StickyGroup>
-              <Button type="submit" disabled={!isDirty || isSubmitting}>
-                Export
-              </Button>
+              <Button type="submit">Export</Button>
             </StickyGroup>
           )}
         </PasswordForm>


### PR DESCRIPTION
### Issue / feature description

`Remove some disabling that was preventing the export of private key (private key is still protected by same validations)`
