### PR TITLE
[BLO-744] Transaction confirm button should be orange on hover

### DIFF
--- a/packages/extension/src/ui/features/actions/transaction/ApproveTransactionScreen/ConfirmScreen.tsx
+++ b/packages/extension/src/ui/features/actions/transaction/ApproveTransactionScreen/ConfirmScreen.tsx
@@ -149,11 +149,7 @@ export const ConfirmScreen: FC<ConfirmScreenProps> = ({
                     <Button
                       isDisabled={confirmButtonDisabled}
                       variant={confirmButtonVariant}
-                      backgroundColor={
-                        !confirmButtonDisabled
-                          ? confirmButtonBackgroundColor ?? "primary.500"
-                          : undefined
-                      }
+                      colorScheme="primary"
                       w="full"
                       type="submit"
                     >
@@ -183,11 +179,7 @@ export const ConfirmScreen: FC<ConfirmScreenProps> = ({
                     )}
                     <Button
                       isDisabled={confirmButtonDisabled}
-                      backgroundColor={
-                        !confirmButtonDisabled
-                          ? confirmButtonBackgroundColor ?? "primary.500"
-                          : undefined
-                      }
+                      colorScheme="primary"
                       variant={confirmButtonVariant}
                       type="submit"
                     >


### PR DESCRIPTION
### Issue / feature description
Now
![image](https://user-images.githubusercontent.com/46749544/220924345-1d910fef-f3e7-488b-bc7f-cfa3545f44e4.png)
