### PR TITLE
BLO-780 fix: remove appstate for managing errors in lock screen

### DIFF
--- a/packages/extension/src/ui/features/lock/LockScreen.tsx
+++ b/packages/extension/src/ui/features/lock/LockScreen.tsx
@@ -64,7 +64,7 @@ export const LockScreen: FC = () => {
                 navigate(target)
                 return true
               } catch {
-                setError("Invalid password")
+                setError("Incorrect password")
                 return false
               } finally {
                 setIsLoading(false)

--- a/packages/extension/src/ui/features/lock/LockScreen.tsx
+++ b/packages/extension/src/ui/features/lock/LockScreen.tsx
@@ -18,7 +18,7 @@ export const LockScreen: FC = () => {
   const navigate = useNavigate()
   const actions = useActions()
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const [error, setError] = useState<string | undefined>(undefined)
+  const [error, setError] = useState<string>()
   return (
     <Flex flex={1} flexDirection={"column"} py={6} px={5}>
       <Flex

--- a/packages/extension/src/ui/features/lock/LockScreen.tsx
+++ b/packages/extension/src/ui/features/lock/LockScreen.tsx
@@ -4,7 +4,6 @@ import { FC, useState } from "react"
 import { Link } from "react-router-dom"
 import { useNavigate } from "react-router-dom"
 
-import { useAppState } from "../../app.state"
 import { routes } from "../../routes"
 import { unlockedExtensionTracking } from "../../services/analytics"
 import { startSession } from "../../services/backgroundSessions"
@@ -19,6 +18,7 @@ export const LockScreen: FC = () => {
   const navigate = useNavigate()
   const actions = useActions()
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | undefined>(undefined)
   return (
     <Flex flex={1} flexDirection={"column"} py={6} px={5}>
       <Flex
@@ -48,6 +48,7 @@ export const LockScreen: FC = () => {
 
         <Box width="100%">
           <PasswordForm
+            error={error}
             verifyPassword={async (password) => {
               setIsLoading(true)
               try {
@@ -63,9 +64,7 @@ export const LockScreen: FC = () => {
                 navigate(target)
                 return true
               } catch {
-                useAppState.setState({
-                  error: "Incorrect password",
-                })
+                setError("Invalid password")
                 return false
               } finally {
                 setIsLoading(false)

--- a/packages/extension/src/ui/features/lock/PasswordForm.tsx
+++ b/packages/extension/src/ui/features/lock/PasswordForm.tsx
@@ -4,7 +4,6 @@ import { isEmpty, isString } from "lodash-es"
 import { FC, ReactNode, useEffect } from "react"
 import { Controller, SubmitHandler, useForm } from "react-hook-form"
 
-import { useAppState } from "../../app.state"
 import { validatePassword } from "../recovery/seedRecovery.state"
 
 interface FieldValues {
@@ -12,11 +11,13 @@ interface FieldValues {
 }
 
 interface PasswordFormProps {
+  error?: string
   verifyPassword: (password: string) => Promise<boolean>
   children?: (options: { isDirty: boolean; isSubmitting: boolean }) => ReactNode
 }
 
 export const PasswordForm: FC<PasswordFormProps> = ({
+  error,
   verifyPassword,
   children,
 }) => {
@@ -25,11 +26,9 @@ export const PasswordForm: FC<PasswordFormProps> = ({
   const { errors, isDirty, isSubmitting } = formState
   const { InfoIcon } = icons
 
-  const { error } = useAppState() // FIXME: as a hack we need to use global storage here, as the password form unmounts for the loading screen
   useEffect(() => {
     if (isString(error)) {
       setError("password", { message: error })
-      useAppState.setState({ error: undefined }) // reset error string once we picked it up
     }
   }, [error, setError])
 


### PR DESCRIPTION
### Issue / feature description

`Tx error is displayed on login screen`

### Changes

- refactored lock screen and form to use local state instead of app state (had registered the tx error)
- tested locally with ionel too (to replicate, send max currency to another account and make another transaction while the first one is still pending)

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
