### PR TITLE
BLO-788 fix: hex names

### DIFF
--- a/packages/extension/src/shared/transactions.ts
+++ b/packages/extension/src/shared/transactions.ts
@@ -1,5 +1,5 @@
 import { lowerCase, upperFirst } from "lodash-es"
-import { Call, Status, TransactionType } from "starknet"
+import { Call, Status, TransactionType, number } from "starknet"
 
 import { WalletAccount } from "./wallet.model"
 
@@ -78,7 +78,9 @@ export function transactionNamesToTitle(
   if (!Array.isArray(names)) {
     names = [names]
   }
-  const entrypointNames = names.map((name) => lowerCase(name))
+  /** backend returns hex selectors for unknown names - filter them out */
+  const nonHexNames = names.filter((name) => !number.isHex(name))
+  const entrypointNames = nonHexNames.map((name) => lowerCase(name))
   const lastName = entrypointNames.pop()
   const title = entrypointNames.length
     ? `${entrypointNames.join(", ")} and ${lastName}`


### PR DESCRIPTION
### Issue / feature description

API responses sometimes contain hex strings for names which end up in the UI

### Changes

- filter hex strings when creating display title

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally