### PR TITLE
BLO-772 fix: use target account for implementation change

### DIFF
--- a/packages/extension/src/ui/features/accountEdit/AccountImplementationScreen.tsx
+++ b/packages/extension/src/ui/features/accountEdit/AccountImplementationScreen.tsx
@@ -13,10 +13,15 @@ import { useNavigate } from "react-router-dom"
 
 import { mapArgentAccountTypeToImplementationKey } from "../../../shared/network/utils"
 import { ArgentAccountType } from "../../../shared/wallet.model"
+import { accountsEqual } from "../../../shared/wallet.service"
 import { AutoColumn } from "../../components/Column"
 import { routes } from "../../routes"
-import { upgradeAccount } from "../../services/backgroundAccounts"
+import {
+  selectAccount,
+  upgradeAccount,
+} from "../../services/backgroundAccounts"
 import { useSelectedAccount } from "../accounts/accounts.state"
+import { useRouteAccount } from "../shield/useRouteAccount"
 
 const { WalletIcon, PluginIcon, MulticallIcon, TickIcon } = icons
 
@@ -79,14 +84,20 @@ const ImplementationItem: FC<ImplementationItemProps> = ({
 }
 
 export const AccountImplementationScreen: FC = () => {
-  const account = useSelectedAccount()
+  const selectedAccount = useSelectedAccount()
+  const account = useRouteAccount()
   const navigate = useNavigate()
 
-  if (!account) {
+  if (!account || !selectedAccount) {
     return <></>
   }
 
+  const isSelectedAccount = accountsEqual(selectedAccount, account)
+
   const handleImplementationClick = (i: Implementation) => async () => {
+    if (!isSelectedAccount) {
+      await selectAccount(account)
+    }
     await upgradeAccount(account, i.id)
     navigate(routes.accountTokens(), { replace: true })
   }


### PR DESCRIPTION
### Issue / feature description

Target account not used for implementation change

### Changes

- use target account and select it before implementation change

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

