### PR TITLE
BLO-813 fix: guards and checks for deleting custom networks

### DIFF
--- a/packages/extension/src/background/transactions/sources/voyager.ts
+++ b/packages/extension/src/background/transactions/sources/voyager.ts
@@ -38,7 +38,7 @@ export async function getTransactionHistory(
   metadataTransactions: Transaction[],
 ) {
   const accountsWithHistory = accountsToPopulate.filter((account) =>
-    Boolean(account.network.explorerUrl),
+    Boolean(account.network?.explorerUrl),
   )
   const transactionsPerAccount = await Promise.all(
     accountsWithHistory.map(async (account) => {

--- a/packages/extension/src/ui/features/accounts/accounts.state.ts
+++ b/packages/extension/src/ui/features/accounts/accounts.state.ts
@@ -45,6 +45,10 @@ export const useAccounts = ({
   const filteredAccounts = useMemo(
     () =>
       accounts
+        .filter((account) => {
+          /** omit if custom network no longer exists */
+          return account.network !== undefined
+        })
         .filter(
           allNetworks
             ? () => true

--- a/packages/extension/src/ui/features/recovery/recovery.service.ts
+++ b/packages/extension/src/ui/features/recovery/recovery.service.ts
@@ -1,6 +1,6 @@
 import { some } from "lodash-es"
 
-import { defaultNetwork } from "../../../shared/network"
+import { defaultNetwork, getNetwork } from "../../../shared/network"
 import { accountsEqual, isDeprecated } from "../../../shared/wallet.service"
 import { useAppState } from "../../app.state"
 import { routes } from "../../routes"
@@ -27,7 +27,12 @@ export const recover = async ({
 }: RecoveryOptions = {}) => {
   try {
     const lastSelectedAccount = await getLastSelectedAccount()
-    networkId ??= lastSelectedAccount?.networkId ?? defaultNetwork.id
+
+    /** validate that network exists (may have been a custom that was deleted), or use default */
+    const network = await getNetwork(
+      lastSelectedAccount?.networkId || networkId || defaultNetwork.id,
+    )
+    networkId = network.id
 
     const allAccounts = await getAccounts(true)
     const walletAccounts = accountsOnNetwork(allAccounts, networkId)

--- a/packages/extension/src/ui/features/settings/NetworkSettingsScreen.tsx
+++ b/packages/extension/src/ui/features/settings/NetworkSettingsScreen.tsx
@@ -19,7 +19,10 @@ import { P } from "../../theme/Typography"
 import { useCustomNetworks, useNetworks } from "../networks/useNetworks"
 import { DappConnection } from "./DappConnection"
 import { useSelectedNetwork } from "./selectedNetwork.state"
-import { validateRemoveNetwork } from "./validateRemoveNetwork"
+import {
+  validateRemoveNetwork,
+  validateRestoreDefaultNetworks,
+} from "./validateRemoveNetwork"
 
 const IconButtonCenter = styled(IconButton)`
   margin: 0 auto;
@@ -95,6 +98,23 @@ export const NetworkSettingsScreen: FC = () => {
     }
   }, [])
 
+  const restoreDefaultsClick = useCallback(async () => {
+    try {
+      const shouldRemoveNetwork = await validateRestoreDefaultNetworks()
+      if (shouldRemoveNetwork) {
+        await restoreDefaultCustomNetworks()
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message)
+        setAlertDialogIsOpen(true)
+      } else {
+        // unexpected, throw to error boundary
+        throw error
+      }
+    }
+  }, [])
+
   const onCancel = useCallback(() => {
     setAlertDialogIsOpen(false)
   }, [])
@@ -139,9 +159,7 @@ export const NetworkSettingsScreen: FC = () => {
 
         {!isDefaultCustomNetworks && (
           <Footer>
-            <RestoreDefaultsButton
-              onClick={async () => await restoreDefaultCustomNetworks()}
-            >
+            <RestoreDefaultsButton onClick={restoreDefaultsClick}>
               <RestoreDefaultsButtonIcon>
                 <RefreshIcon fontSize="inherit" />
               </RestoreDefaultsButtonIcon>

--- a/packages/extension/src/ui/features/settings/validateRemoveNetwork.ts
+++ b/packages/extension/src/ui/features/settings/validateRemoveNetwork.ts
@@ -1,5 +1,6 @@
 import { getNetworkSelector } from "../../../shared/account/selectors"
 import { accountStore } from "../../../shared/account/store"
+import { defaultNetworks } from "../../../shared/network"
 import { useAppState } from "../../app.state"
 
 export const validateRemoveNetwork = async (networkId: string) => {
@@ -18,6 +19,21 @@ export const validateRemoveNetwork = async (networkId: string) => {
       `Network ${networkId} has ${accountsOnNetwork.length} account${
         accountsOnNetwork.length === 1 ? "" : "s"
       } which must be removed before the network can be deleted.`,
+    )
+  }
+
+  return true
+}
+
+/** check if current network id is outside the defaults */
+
+export const validateRestoreDefaultNetworks = async () => {
+  const { switcherNetworkId } = useAppState.getState()
+  const defaultNetworkIds = defaultNetworks.map((network) => network.id)
+
+  if (!defaultNetworkIds.includes(switcherNetworkId)) {
+    throw new Error(
+      `Current network ${switcherNetworkId} is a custom network and cannot be deleted. Change networks before resetting.`,
     )
   }
 


### PR DESCRIPTION
### Issue / feature description

Users are able to reset networks while a custom network and account is selected

### Changes

- additional checks for network selection and existence when resetting and recovering

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally