### PR TITLE
[BLO-767] Hide NFTs tab in send screen if user has none

### DIFF
--- a/packages/extension/src/ui/features/send/SendScreen.tsx
+++ b/packages/extension/src/ui/features/send/SendScreen.tsx
@@ -138,12 +138,14 @@ export const SendScreen: FC = () => {
           >
             Tokens
           </Tab>
-          <Tab
-            active={selectedTab === "nfts"}
-            onClick={() => setSelectedTab("nfts")}
-          >
-            NFTs
-          </Tab>
+          {collectibles.length > 0 && (
+            <Tab
+              active={selectedTab === "nfts"}
+              onClick={() => setSelectedTab("nfts")}
+            >
+              NFTs
+            </Tab>
+          )}
         </TabGroup>
 
         <TabView>


### PR DESCRIPTION
### Issue / feature description

`Only show the NFTs tab if he user has NFTs`
