### PR TITLE
BLO-723 feat: add localhost block explorer

### DIFF
--- a/packages/extension/src/shared/network/defaults.ts
+++ b/packages/extension/src/shared/network/defaults.ts
@@ -70,6 +70,7 @@ export const defaultNetworks: Network[] = [
     id: "localhost",
     chainId: "SN_GOERLI",
     baseUrl: "http://localhost:5050",
+    explorerUrl: "https://devnet.starkscan.co",
     name: "Localhost 5050",
   },
 ]

--- a/packages/extension/src/shared/settings/defaultBlockExplorers.ts
+++ b/packages/extension/src/shared/settings/defaultBlockExplorers.ts
@@ -4,7 +4,8 @@ export const defaultBlockExplorers = {
     url: {
       "mainnet-alpha": "https://starkscan.co",
       "goerli-alpha": "https://testnet.starkscan.co",
-      "goerli-alpha-2": "https://testnet-2.starkscan.co/",
+      "goerli-alpha-2": "https://testnet-2.starkscan.co",
+      localhost: "https://devnet.starkscan.co",
     },
   },
   voyager: {
@@ -12,7 +13,8 @@ export const defaultBlockExplorers = {
     url: {
       "mainnet-alpha": "https://voyager.online",
       "goerli-alpha": "https://goerli.voyager.online",
-      "goerli-alpha-2": "https://goerli-2.voyager.online/",
+      "goerli-alpha-2": "https://goerli-2.voyager.online",
+      localhost: "https://goerli.voyager.online/local-version",
     },
   },
 }

--- a/packages/extension/src/ui/services/blockExplorer.service.ts
+++ b/packages/extension/src/ui/services/blockExplorer.service.ts
@@ -21,7 +21,8 @@ export const getBlockExplorerUrlForNetwork = async (network: Network) => {
   if (
     network.id === "mainnet-alpha" ||
     network.id === "goerli-alpha" ||
-    network.id === "goerli-alpha-2"
+    network.id === "goerli-alpha-2" ||
+    network.id === "localhost"
   ) {
     return settingsBlockExplorer.url[network.id]
   }


### PR DESCRIPTION
### Issue / feature description

Allow user to use block explorer on Localhost

### Changes

- add block explorer urls for localhost

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally
