### PR TITLE
BLO-709 feat: use RPC provider on custom networks

### DIFF
--- a/packages/extension/src/background/transactions/sources/onchain.ts
+++ b/packages/extension/src/background/transactions/sources/onchain.ts
@@ -1,3 +1,5 @@
+import { GetTransactionReceiptResponse, Sequencer, Status } from "starknet"
+
 import { getProvider } from "../../../shared/network"
 import {
   Transaction,
@@ -5,32 +7,43 @@ import {
 } from "../../../shared/transactions"
 import { getTransactionsStatusUpdate } from "../determineUpdates"
 
+const isFailedTransactionReceiptResponse = (
+  receipt: GetTransactionReceiptResponse,
+): receipt is Sequencer.FailedTransactionReceiptResponse => {
+  if ("transaction_failure_reason" in receipt) {
+    return true
+  }
+  return false
+}
+
+/** should never happen - in case the tx status is undefined */
+const FALLBACK_STATUS: Status = "NOT_RECEIVED"
+
 export async function getTransactionsUpdate(transactions: Transaction[]) {
   const transactionsToCheck = getInFlightTransactions(transactions)
 
   // as this function tends to run into 429 errors, we'll simply keep the old status when it fails
   // TODO: we should add a cooldown when user run into 429 errors
   const fetchedTransactions = await Promise.allSettled(
-    transactionsToCheck.map(async (transaction) => {
+    transactionsToCheck.map(async (transaction): Promise<Transaction> => {
       const provider = getProvider(transaction.account.network)
-      const status = await provider.getTransactionStatus(transaction.hash)
+      const receipt = await provider.getTransactionReceipt(transaction.hash)
       return {
         ...transaction,
-        status: status.tx_status,
-        failureReason: status.tx_failure_reason,
+        status: receipt.status || FALLBACK_STATUS,
+        failureReason: isFailedTransactionReceiptResponse(receipt)
+          ? receipt.transaction_failure_reason
+          : undefined,
       }
     }),
   )
 
-  const updatedTransactions = fetchedTransactions.reduce<Transaction[]>(
-    (acc, transaction) => {
-      if (transaction.status === "fulfilled") {
-        acc.push(transaction.value)
-      }
-      return acc
-    },
-    [],
-  )
+  const updatedTransactions = fetchedTransactions.reduce((acc, transaction) => {
+    if (transaction.status === "fulfilled") {
+      acc.push(transaction.value)
+    }
+    return acc
+  }, [] as Transaction[])
 
   return getTransactionsStatusUpdate(transactions, updatedTransactions) // filter out transactions that have not changed
 }

--- a/packages/extension/src/shared/network/provider.ts
+++ b/packages/extension/src/shared/network/provider.ts
@@ -1,5 +1,5 @@
 import { memoize } from "lodash-es"
-import { SequencerProvider } from "starknet"
+import { ProviderInterface, RpcProvider, SequencerProvider } from "starknet"
 import { SequencerProvider as SequencerProviderv4 } from "starknet4"
 
 import { Network } from "./type"
@@ -8,7 +8,14 @@ const getProviderForBaseUrl = memoize((baseUrl: string) => {
   return new SequencerProvider({ baseUrl })
 })
 
-export function getProvider(network: Network) {
+const getProviderForRpcUrl = memoize((rpcUrl: string) => {
+  return new RpcProvider({ nodeUrl: rpcUrl })
+})
+
+export function getProvider(network: Network): ProviderInterface {
+  if (network.rpcUrl) {
+    return getProviderForRpcUrl(network.rpcUrl)
+  }
   return getProviderForBaseUrl(network.baseUrl)
 }
 


### PR DESCRIPTION
### Issue / feature description

Use RPC Provider when RPC url is present in custom network config

### Changes

- refactor to use common `getTransactionReceipt` method instead of sequencer-specific `getTransactionStatus`
- use RPC provider when rpcUrl is present in network

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally