### PR TITLE
fix: use token with balance

### DIFF
--- a/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
+++ b/packages/extension/src/ui/features/accountTokens/TokenScreen.tsx
@@ -91,7 +91,7 @@ export const TokenScreen: FC = () => {
     account,
   })
 
-  const currencyValue = useTokenBalanceToCurrencyValue(token)
+  const currencyValue = useTokenBalanceToCurrencyValue(tokenWithBalance)
   const returnTo = useCurrentPathnameWithQuery()
 
   if (!token) {


### PR DESCRIPTION
### Issue / feature description

USD value missing in token screen

### Changes

- use token object that contains balance

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally