### PR TITLE
BLO-873 fix: 2fa personal message signing

### DIFF
--- a/packages/extension/src/shared/shield/GuardianSignerArgentX.ts
+++ b/packages/extension/src/shared/shield/GuardianSignerArgentX.ts
@@ -1,4 +1,4 @@
-import { GuardianSigner } from "@argent/guardian"
+import { CosignerOffchainMessage, GuardianSigner } from "@argent/guardian"
 import type { CosignerMessage } from "@argent/guardian"
 import type { Signature } from "starknet"
 import { number } from "starknet"
@@ -7,7 +7,8 @@ import { isTokenExpired } from "./backend/account"
 
 export class GuardianSignerArgentX extends GuardianSigner {
   public async cosignMessage(
-    cosignerMessage: CosignerMessage,
+    cosignerMessage: CosignerMessage | CosignerOffchainMessage,
+    isOffchainMessage = false,
   ): Promise<Signature> {
     const tokenExpired = await isTokenExpired()
 
@@ -15,7 +16,7 @@ export class GuardianSignerArgentX extends GuardianSigner {
       throw new Error("Argent Shield token is expired")
     }
 
-    const response = await this.cosigner(cosignerMessage)
+    const response = await this.cosigner(cosignerMessage, isOffchainMessage)
 
     const signature = [
       number.toBN(response.signature.r).toString(),

--- a/packages/guardian/src/services/GuardianSigner.ts
+++ b/packages/guardian/src/services/GuardianSigner.ts
@@ -50,7 +50,7 @@ export class GuardianSigner extends Signer {
     const signatures = await super.signMessage(typedData, accountAddress)
     const cosignerMessage: CosignerOffchainMessage = {
       message: typedData,
-      accountAddress,
+      accountAddress: addAddressPadding(accountAddress),
       chain: "starknet",
     }
 


### PR DESCRIPTION
### Issue / feature description

Wrong endpoint used for personal sign and unexpected payload

### Changes

- pass expected flag in subclass method
- add address padding to request

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally