### PR TITLE
Hotfix/zod-execute-txn

### DIFF
--- a/packages/window/src/types.ts
+++ b/packages/window/src/types.ts
@@ -1,17 +1,13 @@
 import { InvokeFunctionResponse, Signature } from "starknet"
 import { z } from "zod"
 
+const bignumberishSchema = z.union([z.string(), z.number(), z.bigint()])
+
 const callSchema = z.object({
   contractAddress: z.string(),
   entrypoint: z.string(),
-  calldata: z.array(z.string()).optional(),
+  calldata: z.array(bignumberishSchema).optional(),
 })
-
-const bignumberishSchema = z.union([
-  z.string().regex(/^0x[0-9a-fA-F]+$/),
-  z.number(),
-  z.bigint(),
-])
 
 export const typedDataSchema = z.object({
   types: z.record(


### PR DESCRIPTION
### Issue / feature description

This was a bug in EXECUTE_TRANSACTION zod validation schema which expected `calldata` of type string but mintsquare and possibly other dApps sends `calldata` as BigNumberish which is supported by starknet.js . 

### Changes

- Updated Zod validation schema to use BigNumberish Calldata
- Updated BigNumberish schema to use string which are not "hex" as well

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally