### PR TITLE
hotfix: adapt to backend simulation api

### DIFF
--- a/packages/extension/src/shared/transactionSimulation/types.ts
+++ b/packages/extension/src/shared/transactionSimulation/types.ts
@@ -12,7 +12,8 @@ export interface TransactionSimulationApproval {
   tokenAddress: string
   owner: string
   spender: string
-  value: string
+  value?: string
+  tokenId?: string
   details?: TokenDetails
 }
 
@@ -20,7 +21,8 @@ export interface TransactionSimulationTransfer {
   tokenAddress: string
   from: string
   to: string
-  value: string
+  value?: string
+  tokenId?: string
   details?: TokenDetails
 }
 


### PR DESCRIPTION
### Issue / feature description

Adapt to backend changes for ERC721. Backend now responds with `tokenId` for ERC721 and `value` for ERC20.

### Changes

- Build tokens based on value or tokenId

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally
