### PR TITLE
fix: only run dependabot flow for action triggered by dependabot

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -22,6 +22,7 @@ jobs:
       ARGENT_X_STATUS_URL: ${{ secrets.ARGENT_X_STATUS_URL }}
       ARGENT_EXPLORER_BASE_URL: ${{ secrets.ARGENT_EXPLORER_BASE_URL }}
 
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
       ARGENT_X_STATUS_URL: ${{ secrets.ARGENT_X_STATUS_URL }}
       ARGENT_EXPLORER_BASE_URL: ${{ secrets.ARGENT_EXPLORER_BASE_URL }}
 
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: If github.head_ref not filled, we are merging
         run: |


### PR DESCRIPTION
### Issue / feature description

Update action flow:

- Only dependabot.yml should run if action triggered by DependaBot

Note: dependabot.yml already run all the tests.

### Changes

Action flows


### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
