### PR TITLE
BLO-904 feat: check if account can have 2fa enabled

### DIFF
--- a/packages/extension/src/shared/account/details/getImplementation.ts
+++ b/packages/extension/src/shared/account/details/getImplementation.ts
@@ -1,8 +1,11 @@
 import { Call, number } from "starknet"
+import useSWR from "swr"
 
+import { useArgentShieldEnabled } from "../../../ui/features/shield/useArgentShieldEnabled"
 import { getMulticallForNetwork } from "../../multicall"
 import { getNetwork } from "../../network"
 import { BaseWalletAccount } from "../../wallet.model"
+import { getAccountIdentifier } from "../../wallet.service"
 import { uint256ToHexString } from "./util"
 
 /**
@@ -37,4 +40,21 @@ export const getIsCurrentImplementation = async (
       number.toBN(currentImplementation).eq(number.toBN(accountImplementation)),
   )
   return isCurrentImplementation
+}
+
+/**
+ * Returns result of `getIsCurrentImplementation` if shield is enabled and account is defined
+ */
+
+export const useCanEnableArgentShieldForAccount = (
+  account?: BaseWalletAccount,
+) => {
+  const argentShieldEnabled = useArgentShieldEnabled()
+  const { data: canEnableGuardianForAccount } = useSWR(
+    argentShieldEnabled && account
+      ? [getAccountIdentifier(account), "canEnableGuardianForAccount"]
+      : null,
+    () => account && getIsCurrentImplementation(account),
+  )
+  return canEnableGuardianForAccount
 }

--- a/packages/extension/src/ui/features/accountEdit/AccountEditScreen.tsx
+++ b/packages/extension/src/ui/features/accountEdit/AccountEditScreen.tsx
@@ -12,6 +12,7 @@ import { Center, Flex, Image, Spinner } from "@chakra-ui/react"
 import { FC, useCallback, useMemo, useState } from "react"
 import { Link, useNavigate, useParams } from "react-router-dom"
 
+import { useCanEnableArgentShieldForAccount } from "../../../shared/account/details/getImplementation"
 import { settingsStore } from "../../../shared/settings"
 import { useKeyValueStorage } from "../../../shared/storage/hooks"
 import { parseAmount } from "../../../shared/token/amount"
@@ -72,6 +73,9 @@ export const AccountEditScreen: FC = () => {
   }, [navigate, returnTo])
 
   const argentShieldEnabled = useArgentShieldEnabled()
+
+  const canEnableArgentShieldForAccount =
+    useCanEnableArgentShieldForAccount(account)
 
   const experimentalAllowChooseAccount = useKeyValueStorage(
     settingsStore,
@@ -177,7 +181,7 @@ export const AccountEditScreen: FC = () => {
             </Center>
           </Flex>
           <SpacerCell />
-          {argentShieldEnabled && (
+          {argentShieldEnabled && canEnableArgentShieldForAccount && (
             <>
               <ButtonCell
                 as={Link}


### PR DESCRIPTION
### Issue / feature description

Check if an account can have 2fa enabled before showing the option

### Changes

- add hook to check if account is current implementation

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally