### PR TITLE
BLO-892 hotfix: ensure sparse account object

### DIFF
--- a/packages/extension/src/ui/services/backgroundAccounts.ts
+++ b/packages/extension/src/ui/services/backgroundAccounts.ts
@@ -5,6 +5,7 @@ import {
   WalletAccount,
 } from "../../shared/wallet.model"
 import { walletStore } from "../../shared/wallet/walletStore"
+import { Account } from "../features/accounts/Account"
 import { decryptFromBackground, generateEncryptedSecret } from "./crypto"
 
 export const createNewAccount = async (networkId: string) => {
@@ -48,9 +49,19 @@ export const accountsOnNetwork = (
   networkId: string,
 ) => accounts.filter((account) => account.networkId === networkId)
 
+function isNotBaseWalletAccount(
+  account?: BaseWalletAccount,
+): account is Account {
+  return Boolean(account && "toBaseWalletAccount" in account)
+}
+
 export const selectAccount = async (
   account?: BaseWalletAccount,
 ): Promise<void> => {
+  /** coerce to sparse BaseWalletAccount to prevent DataCloneError from full Account class instance on FireFox */
+  if (isNotBaseWalletAccount(account)) {
+    account = account.toBaseWalletAccount()
+  }
   await walletStore.set("selected", account ?? null)
 
   return connectAccount(account)


### PR DESCRIPTION
### Issue / feature description

Users unable to switch network on FireFox (due to DataCloneError on FF)

### Changes

- coerce stored account to the expected sparse object

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally