### PR TITLE
BLO-930 chore: fee error ui

### DIFF
--- a/packages/extension/src/ui/features/actions/feeEstimation/FeeEstimation.tsx
+++ b/packages/extension/src/ui/features/actions/feeEstimation/FeeEstimation.tsx
@@ -1,8 +1,6 @@
-import { L1, L2, P4, TextWithAmount, icons } from "@argent/ui"
-import { Flex, Text } from "@chakra-ui/react"
-import { Collapse } from "@mui/material"
+import { TextWithAmount } from "@argent/ui"
 import { BigNumber } from "ethers"
-import { FC, useEffect, useMemo, useState } from "react"
+import { FC, useEffect, useMemo } from "react"
 import { number } from "starknet"
 
 import { EstimateFeeResponse } from "../../../../shared/messages/TransactionMessage"
@@ -11,19 +9,17 @@ import {
   prettifyTokenAmount,
 } from "../../../../shared/token/price"
 import { Token } from "../../../../shared/token/type"
-import { CopyTooltip } from "../../../components/CopyTooltip"
-import { makeClickable } from "../../../services/a11y"
 import { useAccount } from "../../accounts/accounts.state"
 import { useTokenAmountToCurrencyValue } from "../../accountTokens/tokenPriceHooks"
 import { useFeeTokenBalance } from "../../accountTokens/tokens.service"
 import { useNetworkFeeToken } from "../../accountTokens/tokens.state"
-import { ExtendableControl } from "./styled"
 import { TransactionsFeeEstimationProps } from "./types"
 import { FeeEstimationBox } from "./ui/FeeEstimationBox"
+import { FeeEstimationText } from "./ui/FeeEstimationText"
+import { InsufficientFundsAccordion } from "./ui/InsufficientFundsAccordion"
+import { TransactionFailureAccordion } from "./ui/TransactionFailureAccordion"
 import { getTooltipText, useMaxFeeEstimation } from "./utils"
 import { getParsedError } from "./utils"
-
-const { AlertIcon, ChevronDownIcon } = icons
 
 export const FeeEstimationContainer: FC<TransactionsFeeEstimationProps> = ({
   accountAddress,
@@ -110,11 +106,14 @@ export const FeeEstimation: FC<FeeEstimationProps> = ({
   feeTokenBalance,
   parsedFeeEstimationError,
   showError,
-  showEstimateError,
   showFeeError,
   suggestedMaxFeeCurrencyValue,
 }) => {
-  const [feeEstimateExpanded, setFeeEstimateExpanded] = useState(false)
+  const tooltipText = useMemo(() => {
+    if (fee) {
+      return getTooltipText(fee.suggestedMaxFee, feeTokenBalance)
+    }
+  }, [fee, feeTokenBalance])
   const primaryText = useMemo(() => {
     if (fee) {
       return amountCurrencyValue !== undefined ? (
@@ -147,8 +146,8 @@ export const FeeEstimation: FC<FeeEstimationProps> = ({
           amount={fee.suggestedMaxFee}
           decimals={feeToken.decimals}
         >
-          <L2 color="neutrals.300">
-            (Max &nbsp;
+          <>
+            (Max&nbsp;
             {feeToken ? (
               prettifyTokenAmount({
                 amount: fee.suggestedMaxFee,
@@ -159,83 +158,36 @@ export const FeeEstimation: FC<FeeEstimationProps> = ({
               <>{fee.suggestedMaxFee} Unknown</>
             )}
             )
-          </L2>
+          </>
         </TextWithAmount>
       )
     }
   }, [fee, feeToken, suggestedMaxFeeCurrencyValue])
-  const hasError = !fee && showEstimateError
-  return (
-    <Flex direction="column" gap="1">
-      <FeeEstimationBox
-        tooltipText={getTooltipText(fee?.suggestedMaxFee, feeTokenBalance)}
+  const isLoading = !fee || !feeTokenBalance
+  if (!showError) {
+    return (
+      <FeeEstimationBox>
+        <FeeEstimationText
+          tooltipText={tooltipText}
+          primaryText={primaryText}
+          secondaryText={secondaryText}
+          isLoading={isLoading}
+        />
+      </FeeEstimationBox>
+    )
+  }
+  if (showFeeError) {
+    return (
+      <InsufficientFundsAccordion
+        tooltipText={tooltipText}
         primaryText={primaryText}
         secondaryText={secondaryText}
-        hasError={hasError}
       />
-
-      {showError && (
-        <Flex
-          direction="column"
-          backgroundColor="#330105"
-          boxShadow="menu"
-          p="3.5"
-          borderRadius="xl"
-        >
-          <Flex justifyContent="space-between" alignItems="center">
-            <Flex gap="1" align="center">
-              <Text color="errorText">
-                <AlertIcon />
-              </Text>
-              <L1 color="errorText">
-                {showFeeError
-                  ? "Not enough funds to cover for fees"
-                  : "Transaction failure predicted"}
-              </L1>
-            </Flex>
-            {!showFeeError && (
-              <ExtendableControl
-                {...makeClickable(() => setFeeEstimateExpanded((x) => !x), {
-                  label: "Show error details",
-                })}
-              >
-                <Text color="errorText">
-                  <ChevronDownIcon
-                    style={{
-                      transition: "transform 0.2s ease-in-out",
-                      transform: feeEstimateExpanded
-                        ? "rotate(-180deg)"
-                        : "rotate(0deg)",
-                    }}
-                    height="14px"
-                    width="16px"
-                  />
-                </Text>
-              </ExtendableControl>
-            )}
-          </Flex>
-
-          <Collapse
-            in={feeEstimateExpanded}
-            timeout="auto"
-            style={{
-              maxHeight: "80vh",
-              overflow: "auto",
-            }}
-          >
-            {parsedFeeEstimationError && (
-              <CopyTooltip
-                copyValue={parsedFeeEstimationError}
-                message="Copied"
-              >
-                <P4 color="errorText" pt="3" whiteSpace="pre-wrap">
-                  {parsedFeeEstimationError}
-                </P4>
-              </CopyTooltip>
-            )}
-          </Collapse>
-        </Flex>
-      )}
-    </Flex>
+    )
+  }
+  return (
+    <TransactionFailureAccordion
+      parsedFeeEstimationError={parsedFeeEstimationError}
+    />
   )
 }

--- a/packages/extension/src/ui/features/actions/feeEstimation/ui/CopyErrorIcon.tsx
+++ b/packages/extension/src/ui/features/actions/feeEstimation/ui/CopyErrorIcon.tsx
@@ -1,0 +1,30 @@
+import { CopyTooltip, icons } from "@argent/ui"
+import { Box, Fade, useAccordionItemState } from "@chakra-ui/react"
+import { FC } from "react"
+
+import { FeeEstimationProps } from "../FeeEstimation"
+
+const { CopyIcon } = icons
+
+export const CopyErrorIcon: FC<
+  Pick<FeeEstimationProps, "parsedFeeEstimationError">
+> = ({ parsedFeeEstimationError }) => {
+  const { isOpen } = useAccordionItemState()
+  if (!parsedFeeEstimationError || !isOpen) {
+    return null
+  }
+  return (
+    <Fade in={isOpen}>
+      <CopyTooltip copyValue={parsedFeeEstimationError}>
+        <Box
+          onClick={(e) => {
+            /** prevent accordion from collapsing */
+            e.preventDefault()
+          }}
+        >
+          <CopyIcon />
+        </Box>
+      </CopyTooltip>
+    </Fade>
+  )
+}

--- a/packages/extension/src/ui/features/actions/feeEstimation/ui/FeeEstimationBox.tsx
+++ b/packages/extension/src/ui/features/actions/feeEstimation/ui/FeeEstimationBox.tsx
@@ -1,28 +1,7 @@
-import { L2, P4, icons } from "@argent/ui"
-import { Center, Flex, Spinner, Text, Tooltip } from "@chakra-ui/react"
-import { FC, ReactNode } from "react"
+import { Flex } from "@chakra-ui/react"
+import { FC, PropsWithChildren } from "react"
 
-const { InfoIcon } = icons
-
-interface FeeEstimationBoxProps {
-  title?: ReactNode
-  subtitle?: ReactNode
-  tooltipText?: ReactNode
-  primaryText?: ReactNode
-  secondaryText?: ReactNode
-  isLoading?: boolean
-  hasError?: boolean
-}
-
-export const FeeEstimationBox: FC<FeeEstimationBoxProps> = ({
-  tooltipText,
-  title = "Network fee",
-  subtitle,
-  isLoading = false,
-  hasError = false,
-  primaryText,
-  secondaryText,
-}) => {
+export const FeeEstimationBox: FC<PropsWithChildren> = (props) => {
   return (
     <Flex
       borderRadius="xl"
@@ -32,46 +11,7 @@ export const FeeEstimationBox: FC<FeeEstimationBoxProps> = ({
       boxShadow="menu"
       px={3}
       py={3.5}
-      flexDirection="column"
-      gap={1}
-    >
-      <Flex flexDirection={"row"} justifyContent="space-between">
-        <Center gap="5px" mr={2} flexShrink={0}>
-          <Flex alignItems="center" justifyContent="center" gap="5px">
-            <P4 fontWeight="medium" color="neutrals.300" noOfLines={1}>
-              {title}
-            </P4>
-          </Flex>
-          {tooltipText && (
-            <Tooltip label={tooltipText}>
-              <Text
-                color="neutrals.300"
-                fontSize={"2xs"}
-                cursor="pointer"
-                _hover={{ color: "white" }}
-              >
-                <InfoIcon />
-              </Text>
-            </Tooltip>
-          )}
-        </Center>
-        {isLoading ? (
-          <Spinner size={"sm"} />
-        ) : hasError ? (
-          <P4 fontWeight="medium">Error</P4>
-        ) : (
-          <Flex
-            gap="1"
-            alignItems="center"
-            direction="row-reverse"
-            flexWrap="wrap"
-          >
-            {primaryText && <P4 fontWeight="medium">{primaryText}</P4>}
-            {secondaryText && <L2 color="neutrals.300">{secondaryText}</L2>}
-          </Flex>
-        )}
-      </Flex>
-      {subtitle && <L2 color="neutrals.300">{subtitle}</L2>}
-    </Flex>
+      {...props}
+    />
   )
 }

--- a/packages/extension/src/ui/features/actions/feeEstimation/ui/FeeEstimationText.tsx
+++ b/packages/extension/src/ui/features/actions/feeEstimation/ui/FeeEstimationText.tsx
@@ -1,0 +1,73 @@
+import { L2, P4, icons } from "@argent/ui"
+import {
+  Center,
+  Flex,
+  Spinner,
+  Text,
+  ThemingProps,
+  Tooltip,
+} from "@chakra-ui/react"
+import { FC, ReactNode } from "react"
+
+const { InfoIcon } = icons
+
+export interface FeeEstimationTextProps extends ThemingProps<"Flex"> {
+  title?: ReactNode
+  subtitle?: ReactNode
+  tooltipText?: ReactNode
+  primaryText?: ReactNode
+  secondaryText?: ReactNode
+  isLoading?: boolean
+}
+
+export const FeeEstimationText: FC<FeeEstimationTextProps> = ({
+  colorScheme = "neutrals",
+  tooltipText,
+  title = "Network fee",
+  subtitle,
+  isLoading = false,
+  primaryText,
+  secondaryText,
+}) => {
+  return (
+    <Flex flex={1} flexDirection="column" gap={1}>
+      <Flex flexDirection={"row"} justifyContent="space-between">
+        <Center gap="5px" mr={2} flexShrink={0}>
+          <Flex alignItems="center" justifyContent="center" gap="5px">
+            <P4 fontWeight="medium" color={`${colorScheme}.300`} noOfLines={1}>
+              {title}
+            </P4>
+          </Flex>
+          {tooltipText && (
+            <Tooltip label={tooltipText}>
+              <Text
+                color={`${colorScheme}.300`}
+                fontSize={"2xs"}
+                cursor="pointer"
+                _hover={{ color: "white" }}
+              >
+                <InfoIcon />
+              </Text>
+            </Tooltip>
+          )}
+        </Center>
+        {isLoading ? (
+          <Spinner size={"sm"} />
+        ) : (
+          <Flex
+            gap="1"
+            alignItems="center"
+            direction="row-reverse"
+            flexWrap="wrap"
+          >
+            {primaryText && <P4 fontWeight="medium">{primaryText}</P4>}
+            {secondaryText && (
+              <L2 color={`${colorScheme}.300`}>{secondaryText}</L2>
+            )}
+          </Flex>
+        )}
+      </Flex>
+      {subtitle && <L2 color={`${colorScheme}.300`}>{subtitle}</L2>}
+    </Flex>
+  )
+}

--- a/packages/extension/src/ui/features/actions/feeEstimation/ui/InsufficientFundsAccordion.tsx
+++ b/packages/extension/src/ui/features/actions/feeEstimation/ui/InsufficientFundsAccordion.tsx
@@ -1,0 +1,38 @@
+import { icons } from "@argent/ui"
+import {
+  Accordion,
+  AccordionButton,
+  AccordionItem,
+  AccordionPanel,
+  Flex,
+} from "@chakra-ui/react"
+import { FC } from "react"
+
+import { FeeEstimationText, FeeEstimationTextProps } from "./FeeEstimationText"
+
+const { AlertIcon } = icons
+
+export const InsufficientFundsAccordion: FC<FeeEstimationTextProps> = (
+  props,
+) => {
+  return (
+    <Accordion
+      defaultIndex={[0]}
+      size="sm"
+      colorScheme="error"
+      boxShadow={"menu"}
+    >
+      <AccordionItem>
+        <AccordionButton sx={{ pointerEvents: "none" }}>
+          <Flex mr="auto" textAlign="left" alignItems={"center"}>
+            <AlertIcon display={"inline-block"} fontSize={"base"} mr={1} />
+            Insufficient funds to pay network fee
+          </Flex>
+        </AccordionButton>
+        <AccordionPanel>
+          <FeeEstimationText colorScheme="error" {...props} />
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/packages/extension/src/ui/features/actions/feeEstimation/ui/TransactionFailureAccordion.tsx
+++ b/packages/extension/src/ui/features/actions/feeEstimation/ui/TransactionFailureAccordion.tsx
@@ -1,0 +1,47 @@
+import { AccordionIcon, P4, icons } from "@argent/ui"
+import {
+  Accordion,
+  AccordionButton,
+  AccordionItem,
+  AccordionPanel,
+  Flex,
+} from "@chakra-ui/react"
+import { FC } from "react"
+
+import { FeeEstimationProps } from "../FeeEstimation"
+import { CopyErrorIcon } from "./CopyErrorIcon"
+
+const { AlertIcon } = icons
+
+export const TransactionFailureAccordion: FC<
+  Pick<FeeEstimationProps, "parsedFeeEstimationError">
+> = ({ parsedFeeEstimationError }) => {
+  return (
+    <Accordion allowToggle size="sm" colorScheme="error" boxShadow={"menu"}>
+      <AccordionItem>
+        <AccordionButton>
+          <Flex flex="auto" textAlign="left" alignItems={"center"}>
+            <AlertIcon display={"inline-block"} fontSize={"base"} mr={1} />
+            Transaction failure predicted
+          </Flex>
+          <Flex ml={1} gap={3}>
+            <CopyErrorIcon
+              parsedFeeEstimationError={parsedFeeEstimationError}
+            />
+            <AccordionIcon />
+          </Flex>
+        </AccordionButton>
+        <AccordionPanel
+          sx={{
+            maxHeight: "60vh",
+            overflow: "auto",
+          }}
+        >
+          <P4 color="errorText" whiteSpace="pre-wrap">
+            {parsedFeeEstimationError}
+          </P4>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/packages/storybook/src/features/actions/transaction/CombinedFeeEstimation.stories.tsx
+++ b/packages/storybook/src/features/actions/transaction/CombinedFeeEstimation.stories.tsx
@@ -6,6 +6,7 @@ import {
   combinedFeeEstimationFixture2,
   combinedFeeEstimationFixture3,
   combinedFeeEstimationFixture4,
+  combinedFeeEstimationFixture5,
 } from "./__fixtures__/fees/combinedFeeEstimationFixtures"
 
 export default {
@@ -17,22 +18,27 @@ const Template: ComponentStory<typeof CombinedFeeEstimation> = (props) => (
   <CombinedFeeEstimation {...props} />
 )
 
-export const NoWrap = Template.bind({})
-NoWrap.args = {
-  ...combinedFeeEstimationFixture2,
-}
-
-export const Wrap = Template.bind({})
-Wrap.args = {
-  ...combinedFeeEstimationFixture4,
-}
-
-export const Error = Template.bind({})
-Error.args = {
+export const Scenario1 = Template.bind({})
+Scenario1.args = {
   ...combinedFeeEstimationFixture1,
 }
 
-export const Loading = Template.bind({})
-Loading.args = {
+export const Scenario2 = Template.bind({})
+Scenario2.args = {
+  ...combinedFeeEstimationFixture2,
+}
+
+export const Scenario3 = Template.bind({})
+Scenario3.args = {
   ...combinedFeeEstimationFixture3,
+}
+
+export const Scenario4 = Template.bind({})
+Scenario4.args = {
+  ...combinedFeeEstimationFixture4,
+}
+
+export const Scenario5 = Template.bind({})
+Scenario5.args = {
+  ...combinedFeeEstimationFixture5,
 }

--- a/packages/storybook/src/features/actions/transaction/FeeEstimationText.stories.tsx
+++ b/packages/storybook/src/features/actions/transaction/FeeEstimationText.stories.tsx
@@ -1,13 +1,13 @@
-import { FeeEstimationBox } from "@argent-x/extension/src/ui/features/actions/feeEstimation/ui/FeeEstimationBox"
+import { FeeEstimationText } from "@argent-x/extension/src/ui/features/actions/feeEstimation/ui/FeeEstimationText"
 import { ComponentMeta, ComponentStory } from "@storybook/react"
 
 export default {
-  title: "features/FeeEstimationBox",
-  component: FeeEstimationBox,
-} as ComponentMeta<typeof FeeEstimationBox>
+  title: "features/FeeEstimationText",
+  component: FeeEstimationText,
+} as ComponentMeta<typeof FeeEstimationText>
 
-const Template: ComponentStory<typeof FeeEstimationBox> = (props) => (
-  <FeeEstimationBox {...props} />
+const Template: ComponentStory<typeof FeeEstimationText> = (props) => (
+  <FeeEstimationText {...props} />
 )
 
 const tooltipText =
@@ -54,6 +54,15 @@ CombinedNoWrap.args = {
 export const CombinedWrap = Template.bind({})
 CombinedWrap.args = {
   ...wrap,
+  tooltipText,
+  title: "Network fees",
+  subtitle: "Includes one-time activation fee",
+}
+
+export const CombinedWrapError = Template.bind({})
+CombinedWrapError.args = {
+  ...wrap,
+  colorScheme: "error",
   tooltipText,
   title: "Network fees",
   subtitle: "Includes one-time activation fee",

--- a/packages/storybook/src/features/actions/transaction/__fixtures__/fees/combinedFeeEstimationFixtures.ts
+++ b/packages/storybook/src/features/actions/transaction/__fixtures__/fees/combinedFeeEstimationFixtures.ts
@@ -4,16 +4,6 @@ import { BigNumber } from "ethers"
 import { feeToken } from "../../../../../tokensByNetwork"
 
 export const combinedFeeEstimationFixture1: CombinedFeeEstimationProps = {
-  feeToken,
-  feeTokenBalance: BigNumber.from("9875209405595349"),
-  parsedFeeEstimationError:
-    'Error in the called contract (0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):\nError at pc=0:104:\nGot an exception while executing a hint.\nCairo traceback (most recent call last):\nUnknown location (pc=0:1678)\nUnknown location (pc=0:1664)\n\nError in the called contract (0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):\nError at pc=0:9:\nGot an exception while executing a hint.\nCairo traceback (most recent call last):\nUnknown location (pc=0:1351)\nUnknown location (pc=0:1328)\nUnknown location (pc=0:915)\n\nTraceback (most recent call last):\n  File "<hint32>", line 3, in <module>\nAssertionError: assert_not_zero failed: 0 = 0.',
-  showError: true,
-  showEstimateError: true,
-  showFeeError: false,
-}
-
-export const combinedFeeEstimationFixture2: CombinedFeeEstimationProps = {
   fee: {
     amount: "115227362374192",
     suggestedMaxFee: "691364174245152",
@@ -21,7 +11,7 @@ export const combinedFeeEstimationFixture2: CombinedFeeEstimationProps = {
     maxADFee: "1475511117273204",
   },
   feeToken,
-  feeTokenBalance: BigNumber.from("8000000000000000"),
+  feeTokenBalance: BigNumber.from("9875209405595349"),
   parsedFeeEstimationError: false,
   showError: false,
   showEstimateError: false,
@@ -30,13 +20,38 @@ export const combinedFeeEstimationFixture2: CombinedFeeEstimationProps = {
   totalMaxFee: "2166875291518356",
 }
 
-export const combinedFeeEstimationFixture3: CombinedFeeEstimationProps = {
+export const combinedFeeEstimationFixture2: CombinedFeeEstimationProps = {
+  fee: {
+    amount: "11522",
+    suggestedMaxFee: "69136",
+    accountDeploymentFee: "49183",
+    maxADFee: "147551",
+  },
   feeToken,
-  feeTokenBalance: BigNumber.from("8000000000000000"),
+  feeTokenBalance: BigNumber.from("9875209405595349"),
   parsedFeeEstimationError: false,
   showError: false,
   showEstimateError: false,
   showFeeError: false,
+  totalFee: "60706",
+  totalMaxFee: "216687",
+}
+
+export const combinedFeeEstimationFixture3: CombinedFeeEstimationProps = {
+  fee: {
+    amount: "11522",
+    suggestedMaxFee: "69136",
+    accountDeploymentFee: "49183",
+    maxADFee: "147551",
+  },
+  feeToken,
+  feeTokenBalance: BigNumber.from("9875209405595349"),
+  parsedFeeEstimationError: false,
+  showError: true,
+  showEstimateError: false,
+  showFeeError: true,
+  totalFee: "60706",
+  totalMaxFee: "216687",
 }
 
 export const combinedFeeEstimationFixture4: CombinedFeeEstimationProps = {
@@ -47,11 +62,21 @@ export const combinedFeeEstimationFixture4: CombinedFeeEstimationProps = {
     maxADFee: "147551",
   },
   feeToken,
-  feeTokenBalance: BigNumber.from("8000000000000000"),
-  parsedFeeEstimationError: false,
-  showError: false,
-  showEstimateError: false,
+  feeTokenBalance: BigNumber.from("9875209405595349"),
+  parsedFeeEstimationError:
+    'Error in the called contract (0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):\nError at pc=0:104:\nGot an exception while executing a hint.\nCairo traceback (most recent call last):\nUnknown location (pc=0:1678)\nUnknown location (pc=0:1664)\n\nError in the called contract (0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):\nError at pc=0:9:\nGot an exception while executing a hint.\nCairo traceback (most recent call last):\nUnknown location (pc=0:1351)\nUnknown location (pc=0:1328)\nUnknown location (pc=0:915)\n\nTraceback (most recent call last):\n  File "<hint32>", line 3, in <module>\nAssertionError: assert_not_zero failed: 0 = 0.',
+  showError: true,
+  showEstimateError: true,
   showFeeError: false,
-  totalFee: "60706",
-  totalMaxFee: "216687",
+}
+
+export const combinedFeeEstimationFixture5: CombinedFeeEstimationProps = {
+  fee: undefined,
+  feeToken,
+  feeTokenBalance: BigNumber.from("9875209405595349"),
+  parsedFeeEstimationError:
+    'Error in the called contract (0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):\nError at pc=0:104:\nGot an exception while executing a hint.\nCairo traceback (most recent call last):\nUnknown location (pc=0:1678)\nUnknown location (pc=0:1664)\n\nError in the called contract (0x49d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7):\nError at pc=0:9:\nGot an exception while executing a hint.\nCairo traceback (most recent call last):\nUnknown location (pc=0:1351)\nUnknown location (pc=0:1328)\nUnknown location (pc=0:915)\n\nTraceback (most recent call last):\n  File "<hint32>", line 3, in <module>\nAssertionError: assert_not_zero failed: 0 = 0.',
+  showError: true,
+  showEstimateError: true,
+  showFeeError: false,
 }

--- a/packages/storybook/src/ui/components/Accordion.stories.tsx
+++ b/packages/storybook/src/ui/components/Accordion.stories.tsx
@@ -1,0 +1,53 @@
+import { AccordionIcon, theme } from "@argent/ui"
+import {
+  Accordion,
+  AccordionButton,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+} from "@chakra-ui/react"
+import { getThemingArgTypes } from "@chakra-ui/storybook-addon"
+import { ComponentMeta, ComponentStory } from "@storybook/react"
+
+export default {
+  title: "components/Accordion",
+  component: Accordion,
+  argTypes: {
+    ...getThemingArgTypes(theme, "Accordion"),
+  },
+} as ComponentMeta<typeof Accordion>
+
+const Template: ComponentStory<typeof Accordion> = (props) => (
+  <Accordion {...props}></Accordion>
+)
+
+const children = (
+  <AccordionItem>
+    <AccordionButton>
+      <Box as="span" flex="1" textAlign="left">
+        Section 1 title
+      </Box>
+      <AccordionIcon />
+    </AccordionButton>
+    <AccordionPanel>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat.
+    </AccordionPanel>
+  </AccordionItem>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  allowToggle: true,
+  children,
+}
+
+export const ColorSchemeError = Template.bind({})
+ColorSchemeError.args = {
+  allowToggle: true,
+  size: "sm",
+  colorScheme: "error",
+  children,
+}

--- a/packages/storybook/src/ui/components/Button.stories.tsx
+++ b/packages/storybook/src/ui/components/Button.stories.tsx
@@ -1,6 +1,5 @@
 import { ArrowBackIcon } from "@argent-x/extension/src/ui/components/Icons/MuiIcons"
-import { Button } from "@argent/ui"
-import { theme } from "@argent/ui"
+import { Button, theme } from "@argent/ui"
 import { getThemingArgTypes } from "@chakra-ui/storybook-addon"
 import { ComponentMeta, ComponentStory } from "@storybook/react"
 

--- a/packages/ui/src/components/Accordion.tsx
+++ b/packages/ui/src/components/Accordion.tsx
@@ -1,22 +1,94 @@
 import { accordionAnatomy } from "@chakra-ui/anatomy"
-import { createMultiStyleConfigHelpers } from "@chakra-ui/react"
+import {
+  createMultiStyleConfigHelpers,
+  useAccordionItemState,
+} from "@chakra-ui/react"
+import { useReducedMotion } from "framer-motion"
+import { ComponentProps, FC } from "react"
+
+import { ChevronDownIcon } from "./icons"
+import { typographyStyles } from "./Typography"
 
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(accordionAnatomy.keys)
 
-const baseStyle = definePartsStyle({
-  // define the part you're going to style
-  container: {
-    border: "solid 1px",
-    borderRadius: "lg",
-    color: "neutrals.700",
-  },
-  panel: {
-    color: "white",
-  },
-  icon: {
-    color: "white",
+const baseStyle = definePartsStyle((props) => {
+  const { colorScheme: c } = props
+  return {
+    container:
+      c === "error"
+        ? {
+            bg: "error.900",
+            borderRadius: "lg",
+            color: "error.500",
+            border: "none",
+            overflow: "hidden",
+          }
+        : {
+            border: "solid 1px",
+            borderRadius: "lg",
+            color: "neutrals.700",
+          },
+    panel:
+      c === "error"
+        ? {
+            color: "error.300",
+          }
+        : {
+            color: "white",
+          },
+    icon: {
+      color: "white",
+    },
+    button:
+      c === "error"
+        ? {
+            bg: "error.500",
+            color: "white",
+            _hover: {
+              bg: "error.600",
+            },
+          }
+        : {
+            color: "white",
+          },
+  }
+})
+
+const sizes = {
+  base: definePartsStyle({}),
+  sm: definePartsStyle({
+    button: {
+      p: 3,
+      ...typographyStyles.L1,
+    },
+    panel: {
+      p: 3,
+      ...typographyStyles.P4,
+    },
+  }),
+}
+
+export const accordionTheme = defineMultiStyleConfig({
+  baseStyle,
+  sizes,
+  defaultProps: {
+    size: "base",
   },
 })
 
-export const accordionTheme = defineMultiStyleConfig({ baseStyle })
+export const AccordionIcon: FC<ComponentProps<typeof ChevronDownIcon>> = (
+  props,
+) => {
+  const { isOpen, isDisabled } = useAccordionItemState()
+  const prefersReducedMotion = useReducedMotion()
+  return (
+    <ChevronDownIcon
+      transform={isOpen ? "rotate(-180deg)" : undefined}
+      transition={prefersReducedMotion ? undefined : "transform 0.2s"}
+      transformOrigin={"center"}
+      opacity={isDisabled ? 0.4 : 1}
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
### Issue / feature description

Fee error states should match designs

### Changes

- add accordion theme with error style
- implement for error states in fee estimation

### Checklist

- [x] Rebased to the last commit of the target branch (or merged)
- [x] Code self-reviewed
- [x] Code self-tested
- [x] Tests updated (if needed)
- [x] All tests are passing locally

<img width="339" alt="Screenshot 2023-03-28 at 15 25 08" src="https://user-images.githubusercontent.com/175607/228270494-e0592a48-5696-482f-ab86-9270521d8da1.png">

<img width="342" alt="Screenshot 2023-03-28 at 15 24 54" src="https://user-images.githubusercontent.com/175607/228270487-a63fc1c8-a14e-43cf-bd90-538a333deddc.png">

