### PR TITLE
Recovery phrase UI displays 'i' identically to 'l'

### DIFF
--- a/packages/extension/src/ui/features/recovery/SeedPhrase.tsx
+++ b/packages/extension/src/ui/features/recovery/SeedPhrase.tsx
@@ -14,7 +14,7 @@ const SeedPhraseGrid = styled.div`
 const SeedWordBadge = styled.div`
   padding: 4px 12px 4px 4px;
   border-radius: 20px;
-  font-weight: 600;
+  font-weight: 500;
   font-size: 13px;
   line-height: 18px;
   text-align: center;


### PR DESCRIPTION
On Ubuntu 22.04, using FireFox, the ArgentX wallet's font-weight for seed phrase recovery words displays the letter 'i' identically to the letter 'l'

With recovery seed phrases, it is paramount that each word is displayed clearly and unambiguously so that unscrupulous users do not write down a misspelling, rendering their recovery phrase incorrect. There exist words where this font-weight can result in ambiguous output, such as 'fail' != 'fall' 

For example, here is a screenshot from an ArgentX recovery phrase containing the word 'sail':

![argentxfont](https://user-images.githubusercontent.com/80549215/229304309-88a4ff08-af7b-4fba-af67-96bc18b3e654.png)


Thankfully I recognized that 'sall' is not a word. Setting font-weight to 500 should resolve this.

### Issue / feature description

`Quick description of the issue or the feature that is implemented in the pr ie: add new transitions between screens`

### Changes

`quick list regarding the related changes within the pr`

ie:

- add new transaction transformer
- add new ui

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [ ] Code self-reviewed
- [ ] Code self-tested
- [ ] Tests updated (if needed)
- [ ] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
