### PR TITLE
feat: Add support to receive messages to change block explorer

### DIFF
--- a/packages/extension/manifest/v2.json
+++ b/packages/extension/manifest/v2.json
@@ -45,5 +45,8 @@
     "scripts": ["background.js"],
     "persistent": true
   },
-  "web_accessible_resources": ["inpage.js"]
+  "web_accessible_resources": ["inpage.js"],
+  "externally_connectable": {
+    "matches": ["https://*.voyager.online/*"]
+  }
 }

--- a/packages/extension/manifest/v3.json
+++ b/packages/extension/manifest/v3.json
@@ -45,5 +45,8 @@
       "matches": ["<all_urls>"],
       "resources": ["inpage.js"]
     }
-  ]
+  ],
+  "externally_connectable": {
+    "matches": ["https://*.voyager.online/*"]
+  }
 }

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -10,6 +10,7 @@ import {
   isPreAuthorized,
   migratePreAuthorizations,
 } from "../shared/preAuthorizations"
+import { settingsStore } from "../shared/settings"
 import { delay } from "../shared/utils/delay"
 import { migrateWallet } from "../shared/wallet/storeMigration"
 import { walletStore } from "../shared/wallet/walletStore"
@@ -273,6 +274,29 @@ browser.runtime.onConnect.addListener((port) => {
 })
 
 messageStream.subscribe(handleMessage)
+
+export type ExternalMessage =
+  | {
+      type: "SET_BLOCK_EXPLORER"
+      blockExplorer: "voyager"
+    }
+  | {
+      type: "GET_BLOCK_EXPLORER"
+    }
+
+browser.runtime.onMessageExternal.addListener(
+  (request: ExternalMessage, _, sendResponse) => {
+    switch (request.type) {
+      case "SET_BLOCK_EXPLORER":
+        settingsStore.set("blockExplorerKey", request.blockExplorer)
+        sendResponse("success")
+        break
+      case "GET_BLOCK_EXPLORER":
+        sendResponse(settingsStore.get("blockExplorerKey"))
+        break
+    }
+  },
+)
 
 // open onboarding flow on initial install
 


### PR DESCRIPTION
Adds support to receive message from voyager.online to change the block explorer to voyager.online

### Issue / feature description

Allows voyager block explorer to change the block explorer to voyager by sending one message to Argent simplifying the user flow

### Changes

Adds a receiver for external messages

### Checklist

- [ ] Rebased to the last commit of the target branch (or merged)
- [] Code self-reviewed
- [] Code self-tested
- [] Tests updated (if needed)
- [x] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
