### PR TITLE
feat: allow user to copy call address

### DIFF
--- a/packages/extension/src/ui/features/actions/transaction/ApproveTransactionScreen/TransactionActions.tsx
+++ b/packages/extension/src/ui/features/actions/transaction/ApproveTransactionScreen/TransactionActions.tsx
@@ -34,6 +34,7 @@ export const TransactionActions: FC<TransactionActionsProps> = ({
             <DetailAccordionButton
               label={entryPointToHumanReadable(transaction.entrypoint)}
               value={formatTruncatedAddress(transaction.contractAddress)}
+              copyValue={transaction.contractAddress}
             />
             <DetailAccordionPanel>
               {transaction.calldata?.map((calldata, cdIndex) => (

--- a/packages/ui/src/components/DetailAccordion.tsx
+++ b/packages/ui/src/components/DetailAccordion.tsx
@@ -107,8 +107,9 @@ export const DetailAccordionButton: FC<
   AccordionButtonProps & {
     label?: ReactNode
     value?: ReactNode
+    copyValue?: string
   }
-> = ({ label, value, children, ...rest }) => {
+> = ({ label, value, copyValue, children, ...rest }) => {
   const { isDisabled } = useAccordionItemState()
   return (
     <AccordionButton
@@ -132,10 +133,27 @@ export const DetailAccordionButton: FC<
       {...rest}
     >
       {label && <P4 fontWeight="medium">{label}</P4>}
-      {value && (
-        <P4 color="neutrals.400" fontWeight="medium">
-          {value}
-        </P4>
+      {value && copyValue ? (
+        <CopyTooltip copyValue={copyValue}>
+          <P4
+            _hover={{
+              color: "text",
+            }}
+            cursor="pointer"
+            transitionProperty="color"
+            transitionDuration="fast"
+            color="neutrals.400"
+            fontWeight="medium"
+          >
+            {value}
+          </P4>
+        </CopyTooltip>
+      ) : (
+        value && (
+          <P4 color="neutrals.400" fontWeight="medium">
+            {value}
+          </P4>
+        )
       )}
       {children}
     </AccordionButton>


### PR DESCRIPTION
### Issue / feature description

FreshPizza had a feature request in his VOD https://youtu.be/O1rsu1O07dM?t=620 
He's asking to be able to copy the actions address value from the UI.

### Changes

- Add copyValue to `DetailAccordionRow`
- Copy action address value on click
