### PR TITLE
fix: add esbuild config to drop console in prod build

### DIFF
--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -141,6 +141,7 @@ module.exports = {
           new EsbuildPlugin({
             loader: "tsx",
             target: "es2020",
+            drop: ["console"],
           }),
         ],
         splitChunks: {


### PR DESCRIPTION
### Issue / feature description

addresses #2119

get rid of console logs printed in prod build
<img width="607" alt="image" src="https://github.com/argentlabs/argent-x/assets/11829847/f9dbaef6-ce73-4042-bd68-faf10c60ba81">

### Changes


- add `esbuid` config to drop consoles in prod build
### Checklist

- [x ] Rebased to the last commit of the target branch (or merged)
- [x ] Code self-reviewed
- [x ] Code self-tested
- [ x] Tests updated (if needed)
- [x ] All tests are passing locally

Please keep your pull request as small as possible. If you need to make multiple changes, please create separate pull requests for each change. Create a draft pull request if you need early feedback. This will mark the pull request as a work in progress and prevent it from being reviewed or merged until you are ready.

Please move drafts to the ready for review (regular PR) when you are ready to start the review process and other developers will pick it up from there.
